### PR TITLE
Range interval filter

### DIFF
--- a/src/Core/Content/Cms/ProductListingPageSubscriber.php
+++ b/src/Core/Content/Cms/ProductListingPageSubscriber.php
@@ -36,6 +36,7 @@ final class ProductListingPageSubscriber implements EventSubscriberInterface
             $this->listingFilterConfigurationRepository->getCheckboxListingFilterConfigurations($event->getSalesChannelContext()),
             $this->listingFilterConfigurationRepository->getMultiSelectListingFilterConfigurations($event->getSalesChannelContext()),
             $this->listingFilterConfigurationRepository->getRangeListingFilterConfigurations($event->getSalesChannelContext()),
+            $this->listingFilterConfigurationRepository->getRangeIntervalListingFilterConfigurations($event->getSalesChannelContext()),
         );
 
         $renderDataCollection = $this->renderDataCollectionBuilder->buildRenderDataCollection(

--- a/src/Core/Content/Cms/Service/RenderDataCollectionBuilder.php
+++ b/src/Core/Content/Cms/Service/RenderDataCollectionBuilder.php
@@ -9,9 +9,11 @@ use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\Ch
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\ListingFilterConfigurationCollection;
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\MultiSelect\MultiSelectListingFilterConfigurationEntity;
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\Range\RangeListingFilterConfigurationEntity;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
 use ITB\ITBConfigurableListingFilters\ListingFilter\Checkbox\Storefront\RenderDataBuilderInterface as CheckboxRenderDataBuilder;
 use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Storefront\RenderDataBuilderInterface as MultiSelectRenderDataBuilder;
 use ITB\ITBConfigurableListingFilters\ListingFilter\Range\Storefront\RenderDataBuilderInterface as RangeRenderDataBuilder;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefront\RenderDataBuilderInterface as RangeIntervalRenderDataBuilder;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResultCollection;
 
 final class RenderDataCollectionBuilder implements RenderDataCollectionBuilderInterface
@@ -20,6 +22,7 @@ final class RenderDataCollectionBuilder implements RenderDataCollectionBuilderIn
         private readonly CheckboxRenderDataBuilder $checkboxRenderDataBuilder,
         private readonly MultiSelectRenderDataBuilder $multiSelectRenderDataBuilder,
         private readonly RangeRenderDataBuilder $rangeRenderDataBuilder,
+        private readonly RangeIntervalRenderDataBuilder $rangeIntervalRenderDataBuilder,
     ) {
     }
 
@@ -45,6 +48,11 @@ final class RenderDataCollectionBuilder implements RenderDataCollectionBuilderIn
                 case RangeListingFilterConfigurationEntity::class:
                     $renderDataCollection->add(
                         $this->rangeRenderDataBuilder->buildRenderData($listingFilterConfigurationEntity, $aggregationResults)
+                    );
+                    break;
+                case RangeIntervalListingFilterConfigurationEntity::class:
+                    $renderDataCollection->add(
+                        $this->rangeIntervalRenderDataBuilder->buildRenderData($listingFilterConfigurationEntity, $aggregationResults)
                     );
                     break;
             }

--- a/src/Core/Content/ListingFilterConfiguration/ListingFilterConfigurationCollection.php
+++ b/src/Core/Content/ListingFilterConfiguration/ListingFilterConfigurationCollection.php
@@ -5,15 +5,13 @@ declare(strict_types=1);
 namespace ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration;
 
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\Checkbox\CheckboxListingFilterConfigurationCollection;
-use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\Checkbox\CheckboxListingFilterConfigurationEntity;
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\MultiSelect\MultiSelectListingFilterConfigurationCollection;
-use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\MultiSelect\MultiSelectListingFilterConfigurationEntity;
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\Range\RangeListingFilterConfigurationCollection;
-use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\Range\RangeListingFilterConfigurationEntity;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationCollection;
 use Traversable;
 
 /**
- * @implements \IteratorAggregate<CheckboxListingFilterConfigurationEntity|MultiSelectListingFilterConfigurationEntity|RangeListingFilterConfigurationEntity>
+ * @implements \IteratorAggregate<ListingFilterConfigurationEntity>
  */
 final class ListingFilterConfigurationCollection implements \IteratorAggregate
 {
@@ -21,6 +19,7 @@ final class ListingFilterConfigurationCollection implements \IteratorAggregate
         private readonly CheckboxListingFilterConfigurationCollection $checkboxListingFilterConfigurationCollection,
         private readonly MultiSelectListingFilterConfigurationCollection $multiSelectListingFilterConfigurationCollection,
         private readonly RangeListingFilterConfigurationCollection $rangeListingFilterConfigurationCollection,
+        private readonly RangeIntervalListingFilterConfigurationCollection $rangeIntervalListingFilterConfigurationCollection,
     ) {
     }
 
@@ -30,37 +29,37 @@ final class ListingFilterConfigurationCollection implements \IteratorAggregate
     }
 
     /**
-     * @return array<CheckboxListingFilterConfigurationEntity|MultiSelectListingFilterConfigurationEntity|RangeListingFilterConfigurationEntity>
+     * @return array<ListingFilterConfigurationEntity>
      */
     public function getListingFilterConfigurations(): array
     {
         return $this->sortFilterConfigurations(
             $this->checkboxListingFilterConfigurationCollection,
             $this->multiSelectListingFilterConfigurationCollection,
-            $this->rangeListingFilterConfigurationCollection
+            $this->rangeListingFilterConfigurationCollection,
+            $this->rangeIntervalListingFilterConfigurationCollection
         );
     }
 
     /**
-     * @return array<CheckboxListingFilterConfigurationEntity|MultiSelectListingFilterConfigurationEntity|RangeListingFilterConfigurationEntity>
+     * @return array<ListingFilterConfigurationEntity>
      */
     private function sortFilterConfigurations(
         CheckboxListingFilterConfigurationCollection $checkboxListingFilterConfigurationCollection,
         MultiSelectListingFilterConfigurationCollection $multiSelectListingFilterConfigurationCollection,
         RangeListingFilterConfigurationCollection $rangeListingFilterConfigurationCollection,
+        RangeIntervalListingFilterConfigurationCollection $rangeIntervalListingFilterConfigurationCollection
     ): array {
         $allConfigurations = array_merge(
             $checkboxListingFilterConfigurationCollection->getElements(),
             $multiSelectListingFilterConfigurationCollection->getElements(),
-            $rangeListingFilterConfigurationCollection->getElements()
+            $rangeListingFilterConfigurationCollection->getElements(),
+            $rangeIntervalListingFilterConfigurationCollection->getElements()
         );
 
         usort(
             $allConfigurations,
-            function (
-                CheckboxListingFilterConfigurationEntity|MultiSelectListingFilterConfigurationEntity|RangeListingFilterConfigurationEntity $a,
-                CheckboxListingFilterConfigurationEntity|MultiSelectListingFilterConfigurationEntity|RangeListingFilterConfigurationEntity $b
-            ): int {
+            function (ListingFilterConfigurationEntity $a, ListingFilterConfigurationEntity $b): int {
                 $positionA = $a->getPosition();
                 $positionB = $b->getPosition();
 

--- a/src/Core/Content/ListingFilterConfiguration/ListingFilterConfigurationRepository.php
+++ b/src/Core/Content/ListingFilterConfiguration/ListingFilterConfigurationRepository.php
@@ -7,6 +7,7 @@ namespace ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfigurat
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\Checkbox\CheckboxListingFilterConfigurationCollection;
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\MultiSelect\MultiSelectListingFilterConfigurationCollection;
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\Range\RangeListingFilterConfigurationCollection;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -19,11 +20,13 @@ final class ListingFilterConfigurationRepository implements ListingFilterConfigu
      * @param EntityRepository<CheckboxListingFilterConfigurationCollection> $checkboxListingFilterConfigurationRepository
      * @param EntityRepository<MultiSelectListingFilterConfigurationCollection> $multiSelectListingFilterConfigurationRepository
      * @param EntityRepository<RangeListingFilterConfigurationCollection> $rangeListingFilterConfigurationRepository
+     * @param EntityRepository<RangeIntervalListingFilterConfigurationCollection> $rangeIntervalListingFilterConfigurationRepository
      */
     public function __construct(
         private readonly EntityRepository $checkboxListingFilterConfigurationRepository,
         private readonly EntityRepository $multiSelectListingFilterConfigurationRepository,
         private readonly EntityRepository $rangeListingFilterConfigurationRepository,
+        private readonly EntityRepository $rangeIntervalListingFilterConfigurationRepository
     ) {
     }
 
@@ -46,6 +49,21 @@ final class ListingFilterConfigurationRepository implements ListingFilterConfigu
             $this->buildCriteria($context->getSalesChannelId(), $loadSalesChannel),
             $context->getContext()
         )
+            ->getEntities();
+    }
+
+    public function getRangeIntervalListingFilterConfigurations(
+        SalesChannelContext $context,
+        bool $loadSalesChannel = false
+    ): RangeIntervalListingFilterConfigurationCollection {
+        $criteria = $this->buildCriteria($context->getSalesChannelId(), $loadSalesChannel);
+
+        $criteria->addAssociation('intervals');
+
+        $intervalsAssociation = $criteria->getAssociation('intervals');
+        $intervalsAssociation->addAssociation('rangeIntervalListingFilterConfiguration');
+
+        return $this->rangeIntervalListingFilterConfigurationRepository->search($criteria, $context->getContext())
             ->getEntities();
     }
 

--- a/src/Core/Content/ListingFilterConfiguration/ListingFilterConfigurationRepository.php
+++ b/src/Core/Content/ListingFilterConfiguration/ListingFilterConfigurationRepository.php
@@ -59,6 +59,7 @@ final class ListingFilterConfigurationRepository implements ListingFilterConfigu
         $criteria = $this->buildCriteria($context->getSalesChannelId(), $loadSalesChannel);
 
         $criteria->addAssociation('intervals');
+        $criteria->addAssociation('intervals.rangeIntervalListingFilterConfiguration');
 
         $intervalsAssociation = $criteria->getAssociation('intervals');
         $intervalsAssociation->addAssociation('rangeIntervalListingFilterConfiguration');

--- a/src/Core/Content/ListingFilterConfiguration/ListingFilterConfigurationRepositoryInterface.php
+++ b/src/Core/Content/ListingFilterConfiguration/ListingFilterConfigurationRepositoryInterface.php
@@ -7,6 +7,7 @@ namespace ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfigurat
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\Checkbox\CheckboxListingFilterConfigurationCollection;
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\MultiSelect\MultiSelectListingFilterConfigurationCollection;
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\Range\RangeListingFilterConfigurationCollection;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 interface ListingFilterConfigurationRepositoryInterface
@@ -20,6 +21,11 @@ interface ListingFilterConfigurationRepositoryInterface
         SalesChannelContext $context,
         bool $loadSalesChannel = false
     ): MultiSelectListingFilterConfigurationCollection;
+
+    public function getRangeIntervalListingFilterConfigurations(
+        SalesChannelContext $context,
+        bool $loadSalesChannel = false
+    ): RangeIntervalListingFilterConfigurationCollection;
 
     public function getRangeListingFilterConfigurations(
         SalesChannelContext $context,

--- a/src/Core/Content/ListingFilterConfiguration/RangeInterval/Aggregate/RangeIntervalListingFilterConfigurationIntervalCollection.php
+++ b/src/Core/Content/ListingFilterConfiguration/RangeInterval/Aggregate/RangeIntervalListingFilterConfigurationIntervalCollection.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+
+/**
+ * @extends EntityCollection<RangeIntervalListingFilterConfigurationIntervalEntity>
+ */
+class RangeIntervalListingFilterConfigurationIntervalCollection extends EntityCollection
+{
+    /**
+     * @api
+     */
+    public function getApiAlias(): string
+    {
+        return 'itb_listing_filter_configuration_collection_range_interval_interval';
+    }
+
+    /**
+     * @return array<RangeIntervalListingFilterConfigurationIntervalEntity>
+     */
+    public function getElementsSortedByPosition(): array
+    {
+        $clone = $this->createNew($this->elements);
+        $clone->sort(
+            static function (
+                RangeIntervalListingFilterConfigurationIntervalEntity $a,
+                RangeIntervalListingFilterConfigurationIntervalEntity $b
+            ): int {
+                if ($a->getPosition() === $b->getPosition()) {
+                    return 0;
+                }
+
+                return ($a->getPosition() < $b->getPosition()) ? -1 : 1;
+            },
+        );
+
+        return array_values($clone->getElements());
+    }
+
+    public function getIterator(): \Traversable
+    {
+        yield from $this->getElementsSortedByPosition();
+    }
+
+    /**
+     * @api
+     */
+    protected function getExpectedClass(): string
+    {
+        return RangeIntervalListingFilterConfigurationIntervalEntity::class;
+    }
+}

--- a/src/Core/Content/ListingFilterConfiguration/RangeInterval/Aggregate/RangeIntervalListingFilterConfigurationIntervalDefinition.php
+++ b/src/Core/Content/ListingFilterConfiguration/RangeInterval/Aggregate/RangeIntervalListingFilterConfigurationIntervalDefinition.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+
+class RangeIntervalListingFilterConfigurationIntervalDefinition extends EntityDefinition
+{
+    public const ENTITY_NAME = 'itb_listing_filter_configuration_range_interval_interval';
+
+    public function getCollectionClass(): string
+    {
+        return RangeIntervalListingFilterConfigurationIntervalCollection::class;
+    }
+
+    /**
+     * @return class-string<Entity>
+     */
+    public function getEntityClass(): string
+    {
+        return RangeIntervalListingFilterConfigurationIntervalEntity::class;
+    }
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new Required(), new ApiAware(), new PrimaryKey()),
+
+            (new IntField('min', 'min'))->addFlags(new ApiAware()),
+            (new IntField('max', 'max'))->addFlags(new ApiAware()),
+            (new IntField('position', 'position'))->addFlags(new ApiAware()),
+
+            (new FkField(
+                RangeIntervalListingFilterConfigurationDefinition::ENTITY_NAME . '_id',
+                'rangeIntervalListingFilterConfigurationId',
+                RangeIntervalListingFilterConfigurationDefinition::class,
+                'id'
+            ))->addFlags(new Required()),
+            new ManyToOneAssociationField(
+                'rangeIntervalListingFilterConfiguration',
+                RangeIntervalListingFilterConfigurationDefinition::ENTITY_NAME . '_id',
+                RangeIntervalListingFilterConfigurationDefinition::class,
+                'id'
+            ),
+        ]);
+    }
+
+    protected function getParentDefinitionClass(): string
+    {
+        return RangeIntervalListingFilterConfigurationDefinition::class;
+    }
+}

--- a/src/Core/Content/ListingFilterConfiguration/RangeInterval/Aggregate/RangeIntervalListingFilterConfigurationIntervalEntity.php
+++ b/src/Core/Content/ListingFilterConfiguration/RangeInterval/Aggregate/RangeIntervalListingFilterConfigurationIntervalEntity.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
+
+class RangeIntervalListingFilterConfigurationIntervalEntity extends Entity
+{
+    use EntityIdTrait;
+
+    protected ?int $max = null;
+
+    protected ?int $min = null;
+
+    protected int $position;
+
+    protected RangeIntervalListingFilterConfigurationEntity $rangeIntervalListingFilterConfiguration;
+
+    protected string $rangeIntervalListingFilterConfigurationId;
+
+    public function getCountAggregationName(): string
+    {
+        return $this->rangeIntervalListingFilterConfiguration->getAggregationName() . '_' . $this->getId();
+    }
+
+    public function getIdFromCountAggregationName(string $countAggregationName): string
+    {
+        $prefix = $this->rangeIntervalListingFilterConfiguration->getAggregationName() . '_';
+
+        return str_replace($prefix, '', $countAggregationName);
+    }
+
+    /**
+     * @api
+     */
+    public function getMax(): ?int
+    {
+        return $this->max;
+    }
+
+    /**
+     * @api
+     */
+    public function getMin(): ?int
+    {
+        return $this->min;
+    }
+
+    /**
+     * @api
+     */
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    /**
+     * @return array{
+     *     gte?: int,
+     *     lte?: int
+     * }
+     */
+    public function getRangeForFilter(): array
+    {
+        $range = [];
+        if ($this->min !== null) {
+            $range[RangeFilter::GTE] = $this->min;
+        }
+
+        if ($this->max !== null) {
+            $range[RangeFilter::LTE] = $this->max;
+        }
+
+        return $range;
+    }
+
+    /**
+     * @api
+     */
+    public function getRangeIntervalListingFilterConfiguration(): RangeIntervalListingFilterConfigurationEntity
+    {
+        return $this->rangeIntervalListingFilterConfiguration;
+    }
+
+    /**
+     * @api
+     */
+    public function getRangeIntervalListingFilterConfigurationId(): string
+    {
+        return $this->rangeIntervalListingFilterConfigurationId;
+    }
+
+    /**
+     * @api
+     */
+    public function setMax(?int $max): void
+    {
+        $this->max = $max;
+    }
+
+    /**
+     * @api
+     */
+    public function setMin(?int $min): void
+    {
+        $this->min = $min;
+    }
+
+    /**
+     * @api
+     */
+    public function setPosition(int $position): void
+    {
+        $this->position = $position;
+    }
+
+    /**
+     * @api
+     */
+    public function setRangeIntervalListingFilterConfiguration(
+        RangeIntervalListingFilterConfigurationEntity $rangeIntervalListingFilterConfiguration
+    ): void {
+        $this->rangeIntervalListingFilterConfiguration = $rangeIntervalListingFilterConfiguration;
+    }
+
+    /**
+     * @api
+     */
+    public function setRangeIntervalListingFilterConfigurationId(string $rangeIntervalListingFilterConfigurationId): void
+    {
+        $this->rangeIntervalListingFilterConfigurationId = $rangeIntervalListingFilterConfigurationId;
+    }
+}

--- a/src/Core/Content/ListingFilterConfiguration/RangeInterval/Aggregate/RangeIntervalListingFilterConfigurationTranslationCollection.php
+++ b/src/Core/Content/ListingFilterConfiguration/RangeInterval/Aggregate/RangeIntervalListingFilterConfigurationTranslationCollection.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+
+/**
+ * @extends EntityCollection<RangeIntervalListingFilterConfigurationTranslationEntity>
+ */
+class RangeIntervalListingFilterConfigurationTranslationCollection extends EntityCollection
+{
+    /**
+     * @api
+     */
+    public function getApiAlias(): string
+    {
+        return 'itb_listing_filter_configuration_translation_collection_range_interval';
+    }
+
+    /**
+     * @api
+     */
+    protected function getExpectedClass(): string
+    {
+        return RangeIntervalListingFilterConfigurationTranslationEntity::class;
+    }
+}

--- a/src/Core/Content/ListingFilterConfiguration/RangeInterval/Aggregate/RangeIntervalListingFilterConfigurationTranslationDefinition.php
+++ b/src/Core/Content/ListingFilterConfiguration/RangeInterval/Aggregate/RangeIntervalListingFilterConfigurationTranslationDefinition.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\Aggregate\ListingFilterConfigurationTranslation\ListingFilterConfigurationTranslationDefinition;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+
+class RangeIntervalListingFilterConfigurationTranslationDefinition extends ListingFilterConfigurationTranslationDefinition
+{
+    public const ENTITY_NAME = 'itb_listing_filter_configuration_range_interval_translation';
+
+    public function getCollectionClass(): string
+    {
+        return RangeIntervalListingFilterConfigurationTranslationCollection::class;
+    }
+
+    /**
+     * @return class-string<Entity>
+     */
+    public function getEntityClass(): string
+    {
+        return RangeIntervalListingFilterConfigurationTranslationEntity::class;
+    }
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        $fieldCollection = parent::defineFields();
+
+        $prefixField = new StringField('element_prefix', 'elementPrefix');
+        $prefixField->addFlags(new ApiAware());
+
+        $fieldCollection->add($prefixField);
+
+        $suffixField = new StringField('element_suffix', 'elementSuffix');
+        $suffixField->addFlags(new ApiAware());
+
+        $fieldCollection->add($suffixField);
+
+        return $fieldCollection;
+    }
+
+    protected function getParentDefinitionClass(): string
+    {
+        return RangeIntervalListingFilterConfigurationDefinition::class;
+    }
+}

--- a/src/Core/Content/ListingFilterConfiguration/RangeInterval/Aggregate/RangeIntervalListingFilterConfigurationTranslationEntity.php
+++ b/src/Core/Content/ListingFilterConfiguration/RangeInterval/Aggregate/RangeIntervalListingFilterConfigurationTranslationEntity.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\Aggregate\ListingFilterConfigurationTranslation\ListingFilterConfigurationTranslationEntity;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
+
+class RangeIntervalListingFilterConfigurationTranslationEntity extends ListingFilterConfigurationTranslationEntity
+{
+    protected ?string $elementPrefix = null;
+
+    protected ?string $elementSuffix = null;
+
+    protected RangeIntervalListingFilterConfigurationEntity $rangeIntervalListingFilterConfiguration;
+
+    protected string $rangeIntervalListingFilterConfigurationId;
+
+    /**
+     * @api
+     */
+    public function getElementPrefix(): ?string
+    {
+        return $this->elementPrefix;
+    }
+
+    /**
+     * @api
+     */
+    public function getElementSuffix(): ?string
+    {
+        return $this->elementSuffix;
+    }
+
+    /**
+     * @api
+     */
+    public function getRangeIntervalListingFilterConfiguration(): RangeIntervalListingFilterConfigurationEntity
+    {
+        return $this->rangeIntervalListingFilterConfiguration;
+    }
+
+    /**
+     * @api
+     */
+    public function getRangeIntervalListingFilterConfigurationId(): string
+    {
+        return $this->rangeIntervalListingFilterConfigurationId;
+    }
+
+    /**
+     * @api
+     */
+    public function setElementPrefix(?string $elementPrefix): void
+    {
+        $this->elementPrefix = $elementPrefix;
+    }
+
+    /**
+     * @api
+     */
+    public function setElementSuffix(?string $elementSuffix): void
+    {
+        $this->elementSuffix = $elementSuffix;
+    }
+
+    /**
+     * @api
+     */
+    public function setRangeIntervalListingFilterConfiguration(
+        RangeIntervalListingFilterConfigurationEntity $rangeIntervalListingFilterConfiguration
+    ): void {
+        $this->rangeIntervalListingFilterConfiguration = $rangeIntervalListingFilterConfiguration;
+    }
+
+    /**
+     * @api
+     */
+    public function setRangeIntervalListingFilterConfigurationId(string $rangeIntervalListingFilterConfigurationId): void
+    {
+        $this->rangeIntervalListingFilterConfigurationId = $rangeIntervalListingFilterConfigurationId;
+    }
+}

--- a/src/Core/Content/ListingFilterConfiguration/RangeInterval/RangeIntervalListingFilterConfigurationCollection.php
+++ b/src/Core/Content/ListingFilterConfiguration/RangeInterval/RangeIntervalListingFilterConfigurationCollection.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+
+/**
+ * @extends EntityCollection<RangeIntervalListingFilterConfigurationEntity>
+ */
+class RangeIntervalListingFilterConfigurationCollection extends EntityCollection
+{
+    /**
+     * @api
+     */
+    public function getApiAlias(): string
+    {
+        return 'itb_listing_filter_configuration_collection_range_interval';
+    }
+
+    /**
+     * @api
+     */
+    protected function getExpectedClass(): string
+    {
+        return RangeIntervalListingFilterConfigurationEntity::class;
+    }
+}

--- a/src/Core/Content/ListingFilterConfiguration/RangeInterval/RangeIntervalListingFilterConfigurationDefinition.php
+++ b/src/Core/Content/ListingFilterConfiguration/RangeInterval/RangeIntervalListingFilterConfigurationDefinition.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\ListingFilterConfigurationDefinition;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalDefinition;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationTranslationDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslatedField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslationsAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+
+class RangeIntervalListingFilterConfigurationDefinition extends ListingFilterConfigurationDefinition
+{
+    public const ENTITY_NAME = 'itb_listing_filter_configuration_range_interval';
+
+    public function getCollectionClass(): string
+    {
+        return RangeIntervalListingFilterConfigurationCollection::class;
+    }
+
+    /**
+     * @return class-string<Entity>
+     */
+    public function getEntityClass(): string
+    {
+        return RangeIntervalListingFilterConfigurationEntity::class;
+    }
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        $fieldCollection = parent::defineFields();
+
+        $prefixField = new TranslatedField('elementPrefix');
+        $prefixField->addFlags(new ApiAware());
+
+        $fieldCollection->add($prefixField);
+
+        $suffixField = new TranslatedField('elementSuffix');
+        $suffixField->addFlags(new ApiAware());
+
+        $fieldCollection->add($suffixField);
+
+        $intervalsAssociationField = new OneToManyAssociationField(
+            'intervals',
+            RangeIntervalListingFilterConfigurationIntervalDefinition::class,
+            self::ENTITY_NAME . '_id'
+        );
+        $intervalsAssociationField->addFlags(new ApiAware(), new Required());
+
+        $fieldCollection->add($intervalsAssociationField);
+
+        $translationsAssociationField = new TranslationsAssociationField(
+            RangeIntervalListingFilterConfigurationTranslationDefinition::class,
+            self::ENTITY_NAME . '_id'
+        );
+        $translationsAssociationField->addFlags(new ApiAware(), new Required());
+
+        $fieldCollection->add($translationsAssociationField);
+
+        return $fieldCollection;
+    }
+}

--- a/src/Core/Content/ListingFilterConfiguration/RangeInterval/RangeIntervalListingFilterConfigurationEntity.php
+++ b/src/Core/Content/ListingFilterConfiguration/RangeInterval/RangeIntervalListingFilterConfigurationEntity.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\ListingFilterConfigurationEntity;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalCollection;
+
+class RangeIntervalListingFilterConfigurationEntity extends ListingFilterConfigurationEntity
+{
+    public const TWIG_TEMPLATE = '@Storefront/storefront/component/listing/filter/filter-multi-select.html.twig';
+
+    protected ?string $elementPrefix = null;
+
+    protected ?string $elementSuffix = null;
+
+    protected ?RangeIntervalListingFilterConfigurationIntervalCollection $intervals = null;
+
+    /**
+     * @api
+     */
+    public function getAggregationName(): string
+    {
+        return $this->slugifyDalField($this->dalField);
+    }
+
+    /**
+     * @api
+     */
+    public function getElementPrefix(): ?string
+    {
+        return $this->elementPrefix;
+    }
+
+    /**
+     * @api
+     */
+    public function getElementSuffix(): ?string
+    {
+        return $this->elementSuffix;
+    }
+
+    public function getFilterName(): string
+    {
+        return $this->slugifyDalField($this->dalField);
+    }
+
+    /**
+     * @api
+     */
+    public function getIntervals(): ?RangeIntervalListingFilterConfigurationIntervalCollection
+    {
+        return $this->intervals;
+    }
+
+    /**
+     * @api
+     */
+    public function setElementPrefix(?string $elementPrefix): void
+    {
+        $this->elementPrefix = $elementPrefix;
+    }
+
+    /**
+     * @api
+     */
+    public function setElementSuffix(?string $elementSuffix): void
+    {
+        $this->elementSuffix = $elementSuffix;
+    }
+
+    /**
+     * @api
+     */
+    public function setIntervals(RangeIntervalListingFilterConfigurationIntervalCollection $intervals): void
+    {
+        $this->intervals = $intervals;
+    }
+}

--- a/src/Core/Content/Product/SalesChannel/Listing/ProductListingSubscriber.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/ProductListingSubscriber.php
@@ -23,7 +23,8 @@ final class ProductListingSubscriber implements EventSubscriberInterface
         $listingFilterConfigurationCollection = new ListingFilterConfigurationCollection(
             $this->listingFilterConfigurationRepository->getCheckboxListingFilterConfigurations($event->getSalesChannelContext()),
             $this->listingFilterConfigurationRepository->getMultiSelectListingFilterConfigurations($event->getSalesChannelContext()),
-            $this->listingFilterConfigurationRepository->getRangeListingFilterConfigurations($event->getSalesChannelContext())
+            $this->listingFilterConfigurationRepository->getRangeListingFilterConfigurations($event->getSalesChannelContext()),
+            $this->listingFilterConfigurationRepository->getRangeIntervalListingFilterConfigurations($event->getSalesChannelContext()),
         );
 
         $this->filterCollectionEnricher->enrichFilterCollection(

--- a/src/Core/Content/Product/SalesChannel/Listing/Service/FilterCollectionEnricher.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/Service/FilterCollectionEnricher.php
@@ -8,12 +8,15 @@ use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\Ch
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\ListingFilterConfigurationCollection;
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\MultiSelect\MultiSelectListingFilterConfigurationEntity;
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\Range\RangeListingFilterConfigurationEntity;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
 use ITB\ITBConfigurableListingFilters\ListingFilter\Checkbox\Dal\FilterBuilderInterface as CheckboxFilterBuilder;
 use ITB\ITBConfigurableListingFilters\ListingFilter\Checkbox\Dal\RequestValueBuilderInterface as CheckboxRequestValueBuilder;
 use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Dal\FilterBuilderInterface as MultiSelectFilterBuilder;
 use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Dal\RequestValueBuilderInterface as MultiSelectRequestValueBuilder;
 use ITB\ITBConfigurableListingFilters\ListingFilter\Range\Dal\FilterBuilderInterface as RangeFilterBuilder;
 use ITB\ITBConfigurableListingFilters\ListingFilter\Range\Dal\RequestValueBuilderInterface as RangeRequestValueBuilder;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Dal\FilterBuilderInterface as RangeIntervalFilterBuilder;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Dal\RequestValueBuilderInterface as RangeIntervalRequestValueBuilder;
 use Shopware\Core\Content\Product\SalesChannel\Listing\FilterCollection;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -26,6 +29,8 @@ final class FilterCollectionEnricher implements FilterCollectionEnricherInterfac
         private readonly MultiSelectFilterBuilder $multiSelectFilterBuilder,
         private readonly RangeRequestValueBuilder $rangeRequestValueBuilder,
         private readonly RangeFilterBuilder $rangeFilterBuilder,
+        private readonly RangeIntervalRequestValueBuilder $rangeIntervalRequestValueBuilder,
+        private readonly RangeIntervalFilterBuilder $rangeIntervalFilterBuilder,
     ) {
     }
 
@@ -51,6 +56,12 @@ final class FilterCollectionEnricher implements FilterCollectionEnricherInterfac
                 case RangeListingFilterConfigurationEntity::class:
                     $requestValue = $this->rangeRequestValueBuilder->buildRequestValue($listingFilterConfigurationEntity, $request);
                     $filterCollection->add($this->rangeFilterBuilder->buildFilter($listingFilterConfigurationEntity, $requestValue));
+                    break;
+                case RangeIntervalListingFilterConfigurationEntity::class:
+                    $requestValue = $this->rangeIntervalRequestValueBuilder->buildRequestValue($listingFilterConfigurationEntity, $request);
+                    $filterCollection->add(
+                        $this->rangeIntervalFilterBuilder->buildFilter($listingFilterConfigurationEntity, $requestValue)
+                    );
                     break;
             }
         }

--- a/src/DependencyInjection/services/core.php
+++ b/src/DependencyInjection/services/core.php
@@ -32,6 +32,9 @@ use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Storefront\Rende
 use ITB\ITBConfigurableListingFilters\ListingFilter\Range\Dal\FilterBuilderInterface as RangeFilterBuilderInterface;
 use ITB\ITBConfigurableListingFilters\ListingFilter\Range\Dal\RequestValueBuilderInterface as RangeRequestValueBuilderInterface;
 use ITB\ITBConfigurableListingFilters\ListingFilter\Range\Storefront\RenderDataBuilderInterface as RangeRenderDataBuilder;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Dal\FilterBuilderInterface as RangeIntervalFilterBuilderInterface;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Dal\RequestValueBuilderInterface as RangeIntervalRequestValueBuilderInterface;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefront\RenderDataBuilderInterface as RangeIntervalRenderDataBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
@@ -89,6 +92,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(MultiSelectFilterBuilderInterface::class),
             service(RangeRequestValueBuilderInterface::class),
             service(RangeFilterBuilderInterface::class),
+            service(RangeIntervalRequestValueBuilderInterface::class),
+            service(RangeIntervalFilterBuilderInterface::class),
         ]);
     $services->alias(FilterCollectionEnricherInterface::class, FilterCollectionEnricher::class);
     $services->set(ProductListingSubscriber::class)
@@ -111,6 +116,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(CheckboxRenderDataBuilder::class),
             service(MultiSelectRenderDataBuilder::class),
             service(RangeRenderDataBuilder::class),
+            service(RangeIntervalRenderDataBuilder::class),
         ]);
     $services->alias(RenderDataCollectionBuilderInterface::class, RenderDataCollectionBuilder::class);
     $services->set(SidebarFilterCmsSlotsExtractor::class);

--- a/src/DependencyInjection/services/core.php
+++ b/src/DependencyInjection/services/core.php
@@ -73,9 +73,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // Entity repositories
     $services->set(ListingFilterConfigurationRepository::class)
         ->args([
-            service('itb_listing_filter_configuration_checkbox.repository'),
-            service('itb_listing_filter_configuration_multi_select.repository'),
-            service('itb_listing_filter_configuration_range.repository'),
+            service(CheckboxListingFilterConfigurationDefinition::ENTITY_NAME . '.repository'),
+            service(MultiSelectListingFilterConfigurationDefinition::ENTITY_NAME . '.repository'),
+            service(RangeListingFilterConfigurationDefinition::ENTITY_NAME . '.repository'),
+            service(RangeIntervalListingFilterConfigurationDefinition::ENTITY_NAME . '.repository'),
         ])
         ->alias(ListingFilterConfigurationRepositoryInterface::class, ListingFilterConfigurationRepository::class);
 

--- a/src/DependencyInjection/services/core.php
+++ b/src/DependencyInjection/services/core.php
@@ -17,6 +17,9 @@ use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\Mu
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\MultiSelect\MultiSelectListingFilterConfigurationDefinition;
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\Range\Aggregate\RangeListingFilterConfigurationTranslationDefinition;
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\Range\RangeListingFilterConfigurationDefinition;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalDefinition;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationTranslationDefinition;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationDefinition;
 use ITB\ITBConfigurableListingFilters\Core\Content\Product\SalesChannel\Listing\ProductListingSubscriber;
 use ITB\ITBConfigurableListingFilters\Core\Content\Product\SalesChannel\Listing\Service\FilterCollectionEnricher;
 use ITB\ITBConfigurableListingFilters\Core\Content\Product\SalesChannel\Listing\Service\FilterCollectionEnricherInterface;
@@ -56,6 +59,15 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     ]);
     $services->set(RangeListingFilterConfigurationTranslationDefinition::class)->tag('shopware.entity.definition', [
         'entity' => RangeListingFilterConfigurationTranslationDefinition::ENTITY_NAME,
+    ]);
+    $services->set(RangeIntervalListingFilterConfigurationDefinition::class)->tag('shopware.entity.definition', [
+        'entity' => RangeIntervalListingFilterConfigurationDefinition::ENTITY_NAME,
+    ]);
+    $services->set(RangeIntervalListingFilterConfigurationTranslationDefinition::class)->tag('shopware.entity.definition', [
+        'entity' => RangeIntervalListingFilterConfigurationTranslationDefinition::ENTITY_NAME,
+    ]);
+    $services->set(RangeIntervalListingFilterConfigurationIntervalDefinition::class)->tag('shopware.entity.definition', [
+        'entity' => RangeIntervalListingFilterConfigurationIntervalDefinition::ENTITY_NAME,
     ]);
 
     // Entity repositories

--- a/src/DependencyInjection/services/listing_filter.php
+++ b/src/DependencyInjection/services/listing_filter.php
@@ -33,6 +33,8 @@ use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Dal\RequestVal
 use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Dal\RequestValueBuilderInterface as RangeIntervalRequestValueBuilderInterface;
 use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\RangeAggregationCompatibilityChecker;
 use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\RangeAggregationCompatibilityCheckerInterface;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefront\ElementBuilder;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefront\ElementBuilderInterface;
 use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefront\ElementsExtractor as RangeIntervalElementsExtractor;
 use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefront\ElementsExtractorForNonCompatibleFields as RangeIntervalElementsExtractorForNonCompatibleFields;
 use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefront\ElementsExtractorInterface as RangeIntervalElementsExtractorInterface;
@@ -109,10 +111,13 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(RangeRenderDataBuilder::class)->args([service(InputValueExtractorInterface::class), service('translator')]);
     $services->alias(RangeRenderDataBuilderInterface::class, RangeRenderDataBuilder::class);
 
-    $services->set(RangeIntervalElementsExtractorForNonCompatibleFields::class);
+    $services->set(ElementBuilder::class);
+    $services->alias(ElementBuilderInterface::class, ElementBuilder::class);
+    $services->set(RangeIntervalElementsExtractorForNonCompatibleFields::class)->args([service(ElementBuilderInterface::class)]);
     $services->set(RangeIntervalElementsExtractor::class)->args([
         service(RangeAggregationCompatibilityCheckerInterface::class),
         service(RangeIntervalElementsExtractorForNonCompatibleFields::class),
+        service(ElementBuilderInterface::class),
     ]);
     $services->alias(RangeIntervalElementsExtractorInterface::class, RangeIntervalElementsExtractor::class);
     $services->set(RangeIntervalRenderDataBuilder::class)->args(

--- a/src/DependencyInjection/services/listing_filter.php
+++ b/src/DependencyInjection/services/listing_filter.php
@@ -12,8 +12,8 @@ use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Dal\FilterBuilde
 use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Dal\FilterBuilderInterface as MultiSelectFilterBuilderInterface;
 use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Dal\RequestValueBuilder as MultiSelectRequestValueBuilder;
 use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Dal\RequestValueBuilderInterface as MultiSelectRequestValueBuilderInterface;
-use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Storefront\ElementsExtractor;
-use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Storefront\ElementsExtractorInterface;
+use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Storefront\ElementsExtractor as MultiSelectElementsExtractor;
+use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Storefront\ElementsExtractorInterface as MultiSelectElementsExtractorInterface;
 use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Storefront\RenderDataBuilder as MultiSelectRenderDataBuilder;
 use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Storefront\RenderDataBuilderInterface as MultiSelectRenderDataBuilderInterface;
 use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelectValueSplitter;
@@ -26,8 +26,22 @@ use ITB\ITBConfigurableListingFilters\ListingFilter\Range\Storefront\InputValueE
 use ITB\ITBConfigurableListingFilters\ListingFilter\Range\Storefront\InputValueExtractorInterface;
 use ITB\ITBConfigurableListingFilters\ListingFilter\Range\Storefront\RenderDataBuilder as RangeRenderDataBuilder;
 use ITB\ITBConfigurableListingFilters\ListingFilter\Range\Storefront\RenderDataBuilderInterface as RangeRenderDataBuilderInterface;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Dal\FilterBuilder as RangeIntervalFilterBuilder;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Dal\FilterBuilderForNonCompatibleFields as RangeIntervalFilterBuilderForNonCompatibleFields;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Dal\FilterBuilderInterface as RangeIntervalFilterBuilderInterface;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Dal\RequestValueBuilder as RangeIntervalRequestValueBuilder;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Dal\RequestValueBuilderInterface as RangeIntervalRequestValueBuilderInterface;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\RangeAggregationCompatibilityChecker;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\RangeAggregationCompatibilityCheckerInterface;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefront\ElementsExtractor as RangeIntervalElementsExtractor;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefront\ElementsExtractorForNonCompatibleFields as RangeIntervalElementsExtractorForNonCompatibleFields;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefront\ElementsExtractorInterface as RangeIntervalElementsExtractorInterface;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefront\RenderDataBuilder as RangeIntervalRenderDataBuilder;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefront\RenderDataBuilderInterface as RangeIntervalRenderDataBuilderInterface;
 use ITB\ITBConfigurableListingFilters\ListingFilter\ValueFromRequestExtractor;
 use ITB\ITBConfigurableListingFilters\ListingFilter\ValueFromRequestExtractorInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
+use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
@@ -41,6 +55,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->alias(MultiSelectValueSplitterInterface::class, MultiSelectValueSplitter::class);
     $services->set(ValueFromRequestExtractor::class);
     $services->alias(ValueFromRequestExtractorInterface::class, ValueFromRequestExtractor::class);
+
+    $services->set(RangeAggregationCompatibilityChecker::class)->args([
+        service(EntityDefinitionQueryHelper::class),
+        service(DefinitionInstanceRegistry::class),
+    ]);
+    $services->alias(RangeAggregationCompatibilityCheckerInterface::class, RangeAggregationCompatibilityChecker::class);
 
     // DAL listing filter services
     $services->set(CheckboxFilterBuilder::class);
@@ -61,17 +81,42 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(RangeRequestValueBuilder::class);
     $services->alias(RangeRequestValueBuilderInterface::class, RangeRequestValueBuilder::class);
 
+    $services->set(RangeIntervalFilterBuilderForNonCompatibleFields::class);
+    $services->set(RangeIntervalFilterBuilder::class)->args([
+        service(RangeAggregationCompatibilityCheckerInterface::class),
+        service(RangeIntervalFilterBuilderForNonCompatibleFields::class),
+    ]);
+    $services->alias(RangeIntervalFilterBuilderInterface::class, RangeIntervalFilterBuilder::class);
+    $services->set(RangeIntervalRequestValueBuilder::class)->args([
+        service(ValueFromRequestExtractorInterface::class),
+        service(MultiSelectValueSplitterInterface::class),
+    ]);
+    $services->alias(RangeIntervalRequestValueBuilderInterface::class, RangeIntervalRequestValueBuilder::class);
+
     // Storefront listing filter services
     $services->set(CheckboxRenderDataBuilder::class)->args([service('translator')]);
     $services->alias(CheckboxRenderDataBuilderInterface::class, CheckboxRenderDataBuilder::class);
 
-    $services->set(ElementsExtractor::class);
-    $services->alias(ElementsExtractorInterface::class, ElementsExtractor::class);
-    $services->set(MultiSelectRenderDataBuilder::class)->args([service(ElementsExtractorInterface::class), service('translator')]);
+    $services->set(MultiSelectElementsExtractor::class);
+    $services->alias(MultiSelectElementsExtractorInterface::class, MultiSelectElementsExtractor::class);
+    $services->set(MultiSelectRenderDataBuilder::class)->args(
+        [service(MultiSelectElementsExtractorInterface::class), service('translator')]
+    );
     $services->alias(MultiSelectRenderDataBuilderInterface::class, MultiSelectRenderDataBuilder::class);
 
     $services->set(InputValueExtractor::class);
     $services->alias(InputValueExtractorInterface::class, InputValueExtractor::class);
     $services->set(RangeRenderDataBuilder::class)->args([service(InputValueExtractorInterface::class), service('translator')]);
     $services->alias(RangeRenderDataBuilderInterface::class, RangeRenderDataBuilder::class);
+
+    $services->set(RangeIntervalElementsExtractorForNonCompatibleFields::class);
+    $services->set(RangeIntervalElementsExtractor::class)->args([
+        service(RangeAggregationCompatibilityCheckerInterface::class),
+        service(RangeIntervalElementsExtractorForNonCompatibleFields::class),
+    ]);
+    $services->alias(RangeIntervalElementsExtractorInterface::class, RangeIntervalElementsExtractor::class);
+    $services->set(RangeIntervalRenderDataBuilder::class)->args(
+        [service(RangeIntervalElementsExtractorInterface::class), service('translator')]
+    );
+    $services->alias(RangeIntervalRenderDataBuilderInterface::class, RangeIntervalRenderDataBuilder::class);
 };

--- a/src/ListingFilter/RangeInterval/Dal/FilterBuilder.php
+++ b/src/ListingFilter/RangeInterval/Dal/FilterBuilder.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Dal;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalCollection;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\RangeAggregationCompatibilityCheckerInterface;
+use Shopware\Core\Content\Product\SalesChannel\Listing\Filter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Bucket\FilterAggregation;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Metric\RangeAggregation;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
+
+final class FilterBuilder implements FilterBuilderInterface
+{
+    public function __construct(
+        private readonly RangeAggregationCompatibilityCheckerInterface $rangeAggregationCompatibilityChecker,
+        private readonly FilterBuilderInterface $filterBuilderForNonCompatibleFields,
+    ) {
+    }
+
+    public function buildFilter(RangeIntervalListingFilterConfigurationEntity $configurationEntity, RequestValue $requestValue): Filter
+    {
+        if (! $this->rangeAggregationCompatibilityChecker->isDalFieldRangeAggregationCompatible($configurationEntity->getDalField())) {
+            return $this->filterBuilderForNonCompatibleFields->buildFilter($configurationEntity, $requestValue);
+        }
+
+        $intervalCollection = $configurationEntity->getIntervals();
+        if (! $intervalCollection instanceof RangeIntervalListingFilterConfigurationIntervalCollection) {
+            throw new \RuntimeException('`intervals` not loaded in `RangeIntervalListingFilterConfigurationEntity`');
+        }
+
+        $ranges = [];
+        foreach ($intervalCollection as $interval) {
+            $ranges[] = [
+                'from' => in_array($interval->getMin(), [null, 0], true) ? null : (float) $interval->getMin(),
+                'to' => in_array($interval->getMax(), [null, 0], true) ? null : (float) $interval->getMax(),
+                'key' => $interval->getId(),
+            ];
+        }
+
+        $aggregation = new RangeAggregation(
+            $configurationEntity->getAggregationName(),
+            $configurationEntity->getFullyQualifiedDalField(),
+            $ranges
+        );
+        $filteredAggregation = new FilterAggregation($configurationEntity->getAggregationName(), $aggregation, [
+            new NotFilter(MultiFilter::CONNECTION_AND, [new EqualsFilter($configurationEntity->getFullyQualifiedDalField(), null)]),
+        ]);
+
+        return new Filter(
+            $configurationEntity->getFilterName(),
+            $requestValue->isFiltered(),
+            [$filteredAggregation],
+            new RangeFilter($configurationEntity->getFullyQualifiedDalField(), $requestValue->range()),
+            $requestValue->range()
+        );
+    }
+}

--- a/src/ListingFilter/RangeInterval/Dal/FilterBuilderForNonCompatibleFields.php
+++ b/src/ListingFilter/RangeInterval/Dal/FilterBuilderForNonCompatibleFields.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Dal;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalCollection;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
+use Shopware\Core\Content\Product\SalesChannel\Listing\Filter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Bucket\FilterAggregation;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Metric\CountAggregation;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
+
+final class FilterBuilderForNonCompatibleFields implements FilterBuilderInterface
+{
+    public function buildFilter(RangeIntervalListingFilterConfigurationEntity $configurationEntity, RequestValue $requestValue): Filter
+    {
+        $intervalCollection = $configurationEntity->getIntervals();
+        if (! $intervalCollection instanceof RangeIntervalListingFilterConfigurationIntervalCollection) {
+            throw new \RuntimeException('`intervals` not loaded in `RangeIntervalListingFilterConfigurationEntity`');
+        }
+
+        $aggregations = [];
+        foreach ($intervalCollection as $intervalEntity) {
+            $aggregation = new CountAggregation(
+                $intervalEntity->getCountAggregationName(),
+                $configurationEntity->getFullyQualifiedDalField()
+            );
+            $aggregationFilter = new RangeFilter($configurationEntity->getFullyQualifiedDalField(), $intervalEntity->getRangeForFilter());
+
+            $aggregations[] = new FilterAggregation($intervalEntity->getCountAggregationName(), $aggregation, [$aggregationFilter]);
+        }
+
+        return new Filter(
+            $configurationEntity->getFilterName(),
+            $requestValue->isFiltered(),
+            $aggregations,
+            new RangeFilter($configurationEntity->getFullyQualifiedDalField(), $requestValue->range()),
+            $requestValue->range()
+        );
+    }
+}

--- a/src/ListingFilter/RangeInterval/Dal/FilterBuilderInterface.php
+++ b/src/ListingFilter/RangeInterval/Dal/FilterBuilderInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Dal;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
+use Shopware\Core\Content\Product\SalesChannel\Listing\Filter;
+
+interface FilterBuilderInterface
+{
+    public function buildFilter(RangeIntervalListingFilterConfigurationEntity $configurationEntity, RequestValue $requestValue): Filter;
+}

--- a/src/ListingFilter/RangeInterval/Dal/RequestValue.php
+++ b/src/ListingFilter/RangeInterval/Dal/RequestValue.php
@@ -10,6 +10,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
 final class RequestValue
 {
     /**
+     * @codeCoverageIgnore
+     *
      * @param array<RangeIntervalListingFilterConfigurationIntervalEntity> $intervals
      */
     public function __construct(

--- a/src/ListingFilter/RangeInterval/Dal/RequestValue.php
+++ b/src/ListingFilter/RangeInterval/Dal/RequestValue.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Dal;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
+
+final class RequestValue
+{
+    /**
+     * @param array<RangeIntervalListingFilterConfigurationIntervalEntity> $intervals
+     */
+    public function __construct(
+        private readonly array $intervals,
+    ) {
+    }
+
+    public function isFiltered(): bool
+    {
+        return $this->intervals !== [];
+    }
+
+    /**
+     * @return array{
+     *     gte?: int,
+     *     lte?: int
+     * }
+     */
+    public function range(): array
+    {
+        $gte = null;
+        foreach ($this->intervals as $interval) {
+            if ($interval->getMin() === null) {
+                $gte = null;
+                break;
+            }
+
+            if ($gte === null || $interval->getMin() < $gte) {
+                $gte = $interval->getMin();
+            }
+        }
+
+        $lte = null;
+        foreach ($this->intervals as $interval) {
+            if ($interval->getMax() === null) {
+                $lte = null;
+                break;
+            }
+
+            if ($lte === null || $interval->getMax() > $lte) {
+                $lte = $interval->getMax();
+            }
+        }
+
+        $range = [];
+        if ($gte !== null) {
+            $range[RangeFilter::GTE] = $gte;
+        }
+
+        if ($lte !== null) {
+            $range[RangeFilter::LTE] = $lte;
+        }
+
+        return $range;
+    }
+}

--- a/src/ListingFilter/RangeInterval/Dal/RequestValueBuilder.php
+++ b/src/ListingFilter/RangeInterval/Dal/RequestValueBuilder.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Dal;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalCollection;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
+use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelectValueSplitterInterface;
+use ITB\ITBConfigurableListingFilters\ListingFilter\ValueFromRequestExtractorInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+final class RequestValueBuilder implements RequestValueBuilderInterface
+{
+    /**
+     * @codeCoverageIgnore
+     */
+    public function __construct(
+        private readonly ValueFromRequestExtractorInterface $valueFromRequestExtractor,
+        private readonly MultiSelectValueSplitterInterface $multiSelectValueSplitter,
+    ) {
+    }
+
+    public function buildRequestValue(RangeIntervalListingFilterConfigurationEntity $configurationEntity, Request $request): RequestValue
+    {
+        $idsAsString = $this->valueFromRequestExtractor->extractValueFromRequest($request, $configurationEntity->getFilterName());
+        $ids = $this->multiSelectValueSplitter->splitMultiSelectValue($idsAsString, $configurationEntity);
+
+        $intervalCollection = $configurationEntity->getIntervals();
+        if (! $intervalCollection instanceof RangeIntervalListingFilterConfigurationIntervalCollection) {
+            throw new \RuntimeException('`intervals` not loaded in `RangeIntervalListingFilterConfigurationEntity`');
+        }
+
+        $intervals = [];
+        foreach ($ids as $id) {
+            $interval = $intervalCollection->get($id);
+            if ($interval !== null) {
+                $intervals[] = $interval;
+            }
+        }
+
+        return new RequestValue($intervals);
+    }
+}

--- a/src/ListingFilter/RangeInterval/Dal/RequestValueBuilderInterface.php
+++ b/src/ListingFilter/RangeInterval/Dal/RequestValueBuilderInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Dal;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
+use Symfony\Component\HttpFoundation\Request;
+
+interface RequestValueBuilderInterface
+{
+    public function buildRequestValue(RangeIntervalListingFilterConfigurationEntity $configurationEntity, Request $request): RequestValue;
+}

--- a/src/ListingFilter/RangeInterval/RangeAggregationCompatibilityChecker.php
+++ b/src/ListingFilter/RangeInterval/RangeAggregationCompatibilityChecker.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval;
+
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
+use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FloatField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\PriceField;
+
+final class RangeAggregationCompatibilityChecker implements RangeAggregationCompatibilityCheckerInterface
+{
+    public function __construct(
+        private readonly EntityDefinitionQueryHelper $queryHelper,
+        private readonly DefinitionInstanceRegistry $definitionRegistry,
+    ) {
+    }
+
+    public function isDalFieldRangeAggregationCompatible(string $dalField): bool
+    {
+        // The range aggregation parsing for DBAL requires a field type of PriceField, FloatField or IntField.
+        $definition = $this->definitionRegistry->getByEntityName(ProductDefinition::ENTITY_NAME);
+        $field = $this->queryHelper->getField($dalField, $definition, ProductDefinition::ENTITY_NAME);
+
+        return $field instanceof PriceField || $field instanceof FloatField || $field instanceof IntField;
+    }
+}

--- a/src/ListingFilter/RangeInterval/RangeAggregationCompatibilityCheckerInterface.php
+++ b/src/ListingFilter/RangeInterval/RangeAggregationCompatibilityCheckerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval;
+
+interface RangeAggregationCompatibilityCheckerInterface
+{
+    public function isDalFieldRangeAggregationCompatible(string $dalField): bool;
+}

--- a/src/ListingFilter/RangeInterval/Storefront/ElementBuilder.php
+++ b/src/ListingFilter/RangeInterval/Storefront/ElementBuilder.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefront;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalEntity;
+use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Storefront\Element;
+
+final class ElementBuilder implements ElementBuilderInterface
+{
+    public function buildElement(RangeIntervalListingFilterConfigurationIntervalEntity $rangeIntervalEntity): Element
+    {
+        if ($rangeIntervalEntity->getMin() === null && $rangeIntervalEntity->getMax() === null) {
+            throw new \RuntimeException('Both min and max are null. This should be prevented by the pre-persistence validation.');
+        }
+
+        $prefix = (string) $rangeIntervalEntity->getRangeIntervalListingFilterConfiguration()
+            ->getElementPrefix();
+        $suffix = (string) $rangeIntervalEntity->getRangeIntervalListingFilterConfiguration()
+            ->getElementSuffix();
+
+        if ($rangeIntervalEntity->getMin() === null) {
+            $text = '< ' . $prefix . $rangeIntervalEntity->getMax() . $suffix;
+            return new Element($rangeIntervalEntity->getId(), $text);
+        }
+
+        if ($rangeIntervalEntity->getMax() === null) {
+            $text = '> ' . $prefix . $rangeIntervalEntity->getMin() . $suffix;
+            return new Element($rangeIntervalEntity->getId(), $text);
+        }
+
+        $text = $prefix . $rangeIntervalEntity->getMin() . $suffix . ' - ' . $prefix . $rangeIntervalEntity->getMax() . $suffix;
+        return new Element($rangeIntervalEntity->getId(), $text);
+    }
+}

--- a/src/ListingFilter/RangeInterval/Storefront/ElementBuilderInterface.php
+++ b/src/ListingFilter/RangeInterval/Storefront/ElementBuilderInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefront;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalEntity;
+use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Storefront\Element;
+
+interface ElementBuilderInterface
+{
+    public function buildElement(RangeIntervalListingFilterConfigurationIntervalEntity $rangeIntervalEntity): Element;
+}

--- a/src/ListingFilter/RangeInterval/Storefront/ElementsExtractor.php
+++ b/src/ListingFilter/RangeInterval/Storefront/ElementsExtractor.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefront;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalCollection;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
+use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Storefront\Element;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\RangeAggregationCompatibilityCheckerInterface;
+use RuntimeException;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResultCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Metric\RangeResult;
+
+final class ElementsExtractor implements ElementsExtractorInterface
+{
+    public function __construct(
+        private readonly RangeAggregationCompatibilityCheckerInterface $rangeAggregationCompatibilityChecker,
+        private readonly ElementsExtractorInterface $elementsExtractorForNonCompatibleFields,
+    ) {
+    }
+
+    public function extractElementsFromAggregations(
+        RangeIntervalListingFilterConfigurationEntity $configurationEntity,
+        AggregationResultCollection $aggregationResults
+    ): iterable {
+        if (! $this->rangeAggregationCompatibilityChecker->isDalFieldRangeAggregationCompatible($configurationEntity->getDalField())) {
+            return $this->elementsExtractorForNonCompatibleFields->extractElementsFromAggregations(
+                $configurationEntity,
+                $aggregationResults
+            );
+        }
+
+        $aggregationResult = $aggregationResults->get($configurationEntity->getAggregationName());
+        if (! $aggregationResult instanceof AggregationResult) {
+            throw new RuntimeException(sprintf('The aggregation "%s" could not be found.', $configurationEntity->getAggregationName()));
+        }
+
+        if ($aggregationResult instanceof RangeResult === false) {
+            throw new RuntimeException(
+                sprintf('The aggregation result "%s" is not a range result.', $configurationEntity->getAggregationName())
+            );
+        }
+
+        $intervals = [];
+        foreach (array_keys($aggregationResult->getRanges()) as $intervalId) {
+            $intervalEntity = $configurationEntity->getIntervals()?->get($intervalId);
+            if ($intervalEntity !== null) {
+                $intervals[] = $intervalEntity;
+            }
+        }
+
+        $intervalCollection = new RangeIntervalListingFilterConfigurationIntervalCollection($intervals);
+        foreach ($intervalCollection as $intervalEntity) {
+            $minText = $intervalEntity->getMin() !== null ? (string) $intervalEntity->getMin() : 'test';
+            $maxText = $intervalEntity->getMax() !== null ? (string) $intervalEntity->getMax() : 'test';
+
+            yield new Element($intervalEntity->getId(), $minText . ' - ' . $maxText);
+        }
+    }
+}

--- a/src/ListingFilter/RangeInterval/Storefront/ElementsExtractorForNonCompatibleFields.php
+++ b/src/ListingFilter/RangeInterval/Storefront/ElementsExtractorForNonCompatibleFields.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefront;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalCollection;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
+use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Storefront\Element;
+use RuntimeException;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResultCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Metric\CountResult;
+
+final class ElementsExtractorForNonCompatibleFields implements ElementsExtractorInterface
+{
+    public function extractElementsFromAggregations(
+        RangeIntervalListingFilterConfigurationEntity $configurationEntity,
+        AggregationResultCollection $aggregationResults
+    ): iterable {
+        $intervalCollection = $configurationEntity->getIntervals();
+        if (! $intervalCollection instanceof RangeIntervalListingFilterConfigurationIntervalCollection) {
+            throw new \RuntimeException('`intervals` not loaded in `RangeIntervalListingFilterConfigurationEntity`');
+        }
+
+        $intervals = [];
+        foreach ($intervalCollection as $intervalEntity) {
+            $aggregationResult = $aggregationResults->get($intervalEntity->getCountAggregationName());
+            if (! $aggregationResult instanceof AggregationResult) {
+                throw new RuntimeException(sprintf('The aggregation "%s" could not be found.', $intervalEntity->getCountAggregationName()));
+            }
+
+            if ($aggregationResult instanceof CountResult === false) {
+                throw new RuntimeException(
+                    sprintf('The aggregation result "%s" is not a count result.', $intervalEntity->getCountAggregationName())
+                );
+            }
+
+            if ($aggregationResult->getCount() === 0) {
+                continue;
+            }
+
+            $intervalId = $intervalEntity->getIdFromCountAggregationName($aggregationResult->getName());
+            $intervals[] = $intervalCollection->get($intervalId);
+        }
+
+        $intervalCollection = new RangeIntervalListingFilterConfigurationIntervalCollection(array_filter($intervals));
+        foreach ($intervalCollection as $intervalEntity) {
+            $minText = $intervalEntity->getMin() !== null ? (string) $intervalEntity->getMin() : 'test';
+            $maxText = $intervalEntity->getMax() !== null ? (string) $intervalEntity->getMax() : 'test';
+
+            yield new Element($intervalEntity->getId(), $minText . ' - ' . $maxText);
+        }
+    }
+}

--- a/src/ListingFilter/RangeInterval/Storefront/ElementsExtractorForNonCompatibleFields.php
+++ b/src/ListingFilter/RangeInterval/Storefront/ElementsExtractorForNonCompatibleFields.php
@@ -6,7 +6,6 @@ namespace ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefro
 
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalCollection;
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
-use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Storefront\Element;
 use RuntimeException;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResultCollection;
@@ -14,10 +13,15 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Metric
 
 final class ElementsExtractorForNonCompatibleFields implements ElementsExtractorInterface
 {
+    public function __construct(
+        private readonly ElementBuilderInterface $elementBuilder,
+    ) {
+    }
+
     public function extractElementsFromAggregations(
         RangeIntervalListingFilterConfigurationEntity $configurationEntity,
         AggregationResultCollection $aggregationResults
-    ): iterable {
+    ): array {
         $intervalCollection = $configurationEntity->getIntervals();
         if (! $intervalCollection instanceof RangeIntervalListingFilterConfigurationIntervalCollection) {
             throw new \RuntimeException('`intervals` not loaded in `RangeIntervalListingFilterConfigurationEntity`');
@@ -45,11 +49,11 @@ final class ElementsExtractorForNonCompatibleFields implements ElementsExtractor
         }
 
         $intervalCollection = new RangeIntervalListingFilterConfigurationIntervalCollection(array_filter($intervals));
+        $intervals = [];
         foreach ($intervalCollection as $intervalEntity) {
-            $minText = $intervalEntity->getMin() !== null ? (string) $intervalEntity->getMin() : 'test';
-            $maxText = $intervalEntity->getMax() !== null ? (string) $intervalEntity->getMax() : 'test';
-
-            yield new Element($intervalEntity->getId(), $minText . ' - ' . $maxText);
+            $intervals[] = $this->elementBuilder->buildElement($intervalEntity);
         }
+
+        return $intervals;
     }
 }

--- a/src/ListingFilter/RangeInterval/Storefront/ElementsExtractorInterface.php
+++ b/src/ListingFilter/RangeInterval/Storefront/ElementsExtractorInterface.php
@@ -11,10 +11,10 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Aggreg
 interface ElementsExtractorInterface
 {
     /**
-     * @return \Traversable<Element>
+     * @return array<Element>
      */
     public function extractElementsFromAggregations(
         RangeIntervalListingFilterConfigurationEntity $configurationEntity,
         AggregationResultCollection $aggregationResults
-    ): iterable;
+    ): array;
 }

--- a/src/ListingFilter/RangeInterval/Storefront/ElementsExtractorInterface.php
+++ b/src/ListingFilter/RangeInterval/Storefront/ElementsExtractorInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefront;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
+use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Storefront\Element;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResultCollection;
+
+interface ElementsExtractorInterface
+{
+    /**
+     * @return \Traversable<Element>
+     */
+    public function extractElementsFromAggregations(
+        RangeIntervalListingFilterConfigurationEntity $configurationEntity,
+        AggregationResultCollection $aggregationResults
+    ): iterable;
+}

--- a/src/ListingFilter/RangeInterval/Storefront/RenderDataBuilder.php
+++ b/src/ListingFilter/RangeInterval/Storefront/RenderDataBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefront;
 
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
+use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Storefront\ElementCollection;
 use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Storefront\RenderData;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResultCollection;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -23,12 +24,17 @@ final class RenderDataBuilder implements RenderDataBuilderInterface
         RangeIntervalListingFilterConfigurationEntity $configurationEntity,
         AggregationResultCollection $aggregationResults
     ): RenderData {
+        $elements = new ElementCollection($this->elementsExtractor->extractElementsFromAggregations(
+            $configurationEntity,
+            $aggregationResults
+        ), []);
+
         return new RenderData(
             $configurationEntity->getTwigTemplate(),
             $configurationEntity->getFilterName(),
             $configurationEntity->getDisplayName(),
             self::JS_PLUGIN_SELECTOR,
-            iterator_to_array($this->elementsExtractor->extractElementsFromAggregations($configurationEntity, $aggregationResults)),
+            $elements,
             $this->translator->trans('listing.disabledFilterTooltip')
         );
     }

--- a/src/ListingFilter/RangeInterval/Storefront/RenderDataBuilder.php
+++ b/src/ListingFilter/RangeInterval/Storefront/RenderDataBuilder.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefront;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
+use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Storefront\RenderData;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResultCollection;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class RenderDataBuilder implements RenderDataBuilderInterface
+{
+    public const JS_PLUGIN_SELECTOR = 'itb-listing-filter-multi-select';
+
+    public function __construct(
+        private readonly ElementsExtractorInterface $elementsExtractor,
+        private readonly TranslatorInterface $translator
+    ) {
+    }
+
+    public function buildRenderData(
+        RangeIntervalListingFilterConfigurationEntity $configurationEntity,
+        AggregationResultCollection $aggregationResults
+    ): RenderData {
+        return new RenderData(
+            $configurationEntity->getTwigTemplate(),
+            $configurationEntity->getFilterName(),
+            $configurationEntity->getDisplayName(),
+            self::JS_PLUGIN_SELECTOR,
+            iterator_to_array($this->elementsExtractor->extractElementsFromAggregations($configurationEntity, $aggregationResults)),
+            $this->translator->trans('listing.disabledFilterTooltip')
+        );
+    }
+}

--- a/src/ListingFilter/RangeInterval/Storefront/RenderDataBuilderInterface.php
+++ b/src/ListingFilter/RangeInterval/Storefront/RenderDataBuilderInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefront;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
+use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Storefront\RenderData;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResultCollection;
+
+interface RenderDataBuilderInterface
+{
+    public function buildRenderData(
+        RangeIntervalListingFilterConfigurationEntity $configurationEntity,
+        AggregationResultCollection $aggregationResults
+    ): RenderData;
+}

--- a/src/Migration/Migration1743544956CreateFilterConfigurationTables.php
+++ b/src/Migration/Migration1743544956CreateFilterConfigurationTables.php
@@ -121,6 +121,57 @@ CREATE TABLE IF NOT EXISTS `itb_listing_filter_configuration_range_translation` 
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 SQL;
         $connection->executeStatement($sql);
+
+        $sql = <<<SQL
+CREATE TABLE IF NOT EXISTS `itb_listing_filter_configuration_range_interval` (
+    `id` BINARY(16) NOT NULL,
+    `sales_channel_id` BINARY(16) NULL,
+    `dal_field` VARCHAR(255) NOT NULL,
+    `enabled` TINYINT(1) NOT NULL,
+    `position` INTEGER NULL,
+    `twig_template` VARCHAR(255) NOT NULL,
+    `created_at` DATETIME(3) NOT NULL,
+    `updated_at` DATETIME(3) NULL,
+    PRIMARY KEY (`id`),
+    KEY `fk.itb_lfc_range.sales_channel_id` (`sales_channel_id`),
+    CONSTRAINT `fk.itb_lfc_range_interval.sales_channel_id` FOREIGN KEY (`sales_channel_id`) REFERENCES `sales_channel` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+SQL;
+        $connection->executeStatement($sql);
+
+        $sql = <<<SQL
+CREATE TABLE IF NOT EXISTS `itb_listing_filter_configuration_range_interval_translation` (
+    `itb_listing_filter_configuration_range_interval_id` BINARY(16) NOT NULL,
+    `language_id` BINARY(16) NOT NULL,
+    `display_name` VARCHAR(255) NOT NULL,
+    `element_prefix` VARCHAR(255) NULL,
+    `element_suffix` VARCHAR(255) NULL,
+    `created_at` DATETIME(3) NOT NULL,
+    `updated_at` DATETIME(3) NULL,
+    PRIMARY KEY (`itb_listing_filter_configuration_range_interval_id`, `language_id`),
+    CONSTRAINT `fk.itb_lfc_translation_range_interval.entity_id` FOREIGN KEY (`itb_listing_filter_configuration_range_interval_id`)
+        REFERENCES `itb_listing_filter_configuration_range_interval` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT `fk.itb_lfc_translation_range_interval.language_id` FOREIGN KEY (`language_id`)
+        REFERENCES `language` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+SQL;
+        $connection->executeStatement($sql);
+
+        $sql = <<<SQL
+CREATE TABLE IF NOT EXISTS `itb_listing_filter_configuration_range_interval_interval` (
+    `id` BINARY(16) NOT NULL,
+    `itb_listing_filter_configuration_range_interval_id` BINARY(16) NOT NULL,
+    `min` INTEGER NULL,
+    `max` INTEGER NULL,
+    `position` INTEGER NOT NULL,
+    `created_at` DATETIME(3) NOT NULL,
+    `updated_at` DATETIME(3) NULL,
+    PRIMARY KEY (`id`),
+    CONSTRAINT `fk.itb_lfc_interval_range_interval.entity_id` FOREIGN KEY (`itb_listing_filter_configuration_range_interval_id`)
+        REFERENCES `itb_listing_filter_configuration_range_interval` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+SQL;
+        $connection->executeStatement($sql);
     }
 
     public function updateDestructive(Connection $connection): void

--- a/src/Resources/app/administration/src/component/itb-configurable-listing-filters-form-range-interval-interval/index.ts
+++ b/src/Resources/app/administration/src/component/itb-configurable-listing-filters-form-range-interval-interval/index.ts
@@ -1,0 +1,126 @@
+import template from './itb-configurable-listing-filters-form-range-interval-interval.html.twig';
+
+const { mapPropertyErrors } = Shopware.Component.getComponentHelper();
+
+interface DataGridColumn {
+    property: string;
+    label: string;
+    inlineEdit: string;
+    width: string;
+}
+
+interface DataGridRecord {
+    id: string;
+    min: number | null;
+    max: number | null;
+    position: number;
+}
+
+// eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
+Shopware.Component.register('itb-configurable-listing-filters-form-range-interval-interval', {
+    template,
+
+    inject: [
+        'repositoryFactory',
+    ],
+
+    props: {
+        listingFilterConfiguration: {
+            type: Object as () => EntitySchema.itb_listing_filter_configuration_range_interval,
+            required: false,
+            default: null
+        }
+    },
+
+    computed: {
+        ...mapPropertyErrors('listingFilterConfiguration', [
+            'intervals',
+        ]),
+
+        dataGridColumns(): Array<DataGridColumn> {
+            return [
+                {
+                    property: 'min',
+                    label: this.$tc('itb-configurable-listing-filters.form.rangeInterval.interval.labelMin'),
+                    inlineEdit: 'number',
+                    width: '150px'
+                },
+                {
+                    property: 'max',
+                    label: this.$tc('itb-configurable-listing-filters.form.rangeInterval.interval.labelMax'),
+                    inlineEdit: 'number',
+                    width: '150px'
+                },
+                {
+                    property: 'position',
+                    label: this.$tc('itb-configurable-listing-filters.form.rangeInterval.interval.labelPosition'),
+                    inlineEdit: 'number',
+                    width: '150px'
+                }
+            ];
+        },
+
+        dataGridRecords(): Array<DataGridRecord> {
+            const sortedIntervals = [...this.listingFilterConfiguration.intervals].sort((a, b) => {
+                return a.position - b.position;
+            });
+
+            const records: Array<DataGridRecord> = [];
+            sortedIntervals.forEach(interval => {
+                records.push({
+                    id: interval.id,
+                    min: interval.min,
+                    max: interval.max,
+                    position: interval.position
+                });
+            });
+
+            return records;
+        },
+
+        intervalRepository() {
+            return this.repositoryFactory.create('itb_listing_filter_configuration_range_interval_interval');
+        },
+    },
+
+    methods: {
+        onInlineEditFinish(item: DataGridRecord) {
+            if (this.listingFilterConfiguration.intervals && this.listingFilterConfiguration.intervals.length > 0) {
+                this.listingFilterConfiguration.intervals.forEach(existingInterval => {
+                    if (item.id === existingInterval.id) {
+                        existingInterval.min = item.min;
+                        existingInterval.max = item.max;
+                        existingInterval.position = item.position;
+                    }
+                });
+            }
+        },
+
+        onIntervalAdd(): void {
+            const interval: EntitySchema.itb_listing_filter_configuration_range_interval_interval = this.intervalRepository.create();
+
+            let highestPosition = 0;
+            if (this.listingFilterConfiguration.intervals && this.listingFilterConfiguration.intervals.length > 0) {
+                this.listingFilterConfiguration.intervals.forEach(existingInterval => {
+                    if (existingInterval.position > highestPosition) {
+                        highestPosition = existingInterval.position;
+                    }
+                });
+            }
+
+            interval.min = null;
+            interval.max = null;
+            interval.position = highestPosition + 1;
+
+            this.listingFilterConfiguration.intervals.push(interval);
+        },
+
+        onIntervalDelete(interval: DataGridRecord): void {
+            const index = this.listingFilterConfiguration.intervals.findIndex(item => item.id === interval.id);
+
+            if (index !== -1) {
+                this.listingFilterConfiguration.intervals.splice(index, 1);
+            }
+        },
+    }
+});

--- a/src/Resources/app/administration/src/component/itb-configurable-listing-filters-form-range-interval-interval/itb-configurable-listing-filters-form-range-interval-interval.html.twig
+++ b/src/Resources/app/administration/src/component/itb-configurable-listing-filters-form-range-interval-interval/itb-configurable-listing-filters-form-range-interval-interval.html.twig
@@ -1,0 +1,63 @@
+<!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+{% block itb_configurable_listing_filter_form_range_interval_interval %}
+<div class="itb-configurable-listing-filter-form-range-interval-interval">
+    <sw-container columns="1fr" gap="0 30px">
+        <sw-data-grid
+            v-if="listingFilterConfiguration.intervals && listingFilterConfiguration.intervals.length > 0"
+            :dataSource="dataGridRecords"
+            :columns="dataGridColumns"
+            :showSelection="false"
+            :showActions="true"
+            :allowInlineEdit="true"
+            :allowColumnEdit="false"
+            @inline-edit-save="onInlineEditFinish"
+            identifier="itb-configurable-listing-filter-form-range-interval-interval-grid">
+
+            <template #actions="{ item }">
+                <sw-context-menu-item variant="danger" @click="onIntervalDelete(item)">
+                    {{ $tc('itb-configurable-listing-filters.form.rangeInterval.interval.buttonDeleteInterval') }}
+                </sw-context-menu-item>
+            </template>
+
+            <template #column-min="{ item, column, isInlineEdit }">
+                <template v-if="isInlineEdit">
+                    <sw-number-field
+                        :allow-empty="true"
+                        :numberType="'int'"
+                        v-model="item.min">
+                    </sw-number-field>
+                </template>
+                <template v-else>
+                    {{ item.min !== null ? item.min : '-∞' }}
+                </template>
+            </template>
+
+            <template #column-max="{ item, column, isInlineEdit }">
+                <template v-if="isInlineEdit">
+                    <sw-number-field
+                        :allow-empty="true"
+                        :numberType="'int'"
+                        v-model="item.max">
+                    </sw-number-field>
+                </template>
+                <template v-else>
+                    {{ item.max !== null ? item.max : '∞' }}
+                </template>
+            </template>
+
+            <template #column-position="{ item, column, isInlineEdit }">
+                <template v-if="isInlineEdit">
+                    <sw-number-field v-model="item.position" :min="0"></sw-number-field>
+                </template>
+                <template v-else>
+                    {{ item.position }}
+                </template>
+            </template>
+        </sw-data-grid>
+
+        <sw-button class="sw-button-margin-top" @click="onIntervalAdd">
+            {{ $tc('itb-configurable-listing-filters.form.rangeInterval.interval.buttonAddInterval') }}
+        </sw-button>
+    </sw-container>
+</div>
+{% endblock %}

--- a/src/Resources/app/administration/src/component/itb-configurable-listing-filters-form-range-interval/index.ts
+++ b/src/Resources/app/administration/src/component/itb-configurable-listing-filters-form-range-interval/index.ts
@@ -1,0 +1,27 @@
+import template from './itb-configurable-listing-filters-form-range-interval.html.twig';
+
+const { mapPropertyErrors } = Shopware.Component.getComponentHelper();
+
+// eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
+Shopware.Component.register('itb-configurable-listing-filters-form-range-interval', {
+    template,
+
+    inject: [
+        'repositoryFactory',
+    ],
+
+    props: {
+        listingFilterConfiguration: {
+            type: Object as () => EntitySchema.itb_listing_filter_configuration_range_interval,
+            required: false,
+            default: null
+        }
+    },
+
+    computed: {
+        ...mapPropertyErrors('listingFilterConfiguration', [
+            'elementPrefix',
+            'elementSuffix',
+        ]),
+    },
+});

--- a/src/Resources/app/administration/src/component/itb-configurable-listing-filters-form-range-interval/itb-configurable-listing-filters-form-range-interval.html.twig
+++ b/src/Resources/app/administration/src/component/itb-configurable-listing-filters-form-range-interval/itb-configurable-listing-filters-form-range-interval.html.twig
@@ -1,0 +1,26 @@
+<!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+{% block itb_configurable_listing_filter_form_range_interval %}
+<div class="itb-configurable-listing-filter-form-range-interval">
+    <sw-container columns="1fr 1fr" gap="0 30px">
+        <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+        {% block itb_configurable_listing_filter_form_range_interval_element_prefix %}
+        <sw-text-field
+            v-model="listingFilterConfiguration.elementPrefix"
+            :label="$tc('itb-configurable-listing-filters.form.rangeInterval.labelElementPrefix')"
+            :placeholder="$tc('itb-configurable-listing-filters.form.rangeInterval.placeholderElementPrefix')"
+            :error="listingFilterConfigurationElementPrefixError">
+        </sw-text-field>
+        {% endblock %}
+
+        <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+        {% block itb_configurable_listing_filter_form_range_interval_element_suffix %}
+        <sw-text-field
+            v-model="listingFilterConfiguration.elementSuffix"
+            :label="$tc('itb-configurable-listing-filters.form.rangeInterval.labelElementSuffix')"
+            :placeholder="$tc('itb-configurable-listing-filters.form.rangeInterval.placeholderElementSuffix')"
+            :error="listingFilterConfigurationElementSuffixError">
+        </sw-text-field>
+        {% endblock %}
+    </sw-container>
+</div>
+{% endblock %}

--- a/src/Resources/app/administration/src/main.ts
+++ b/src/Resources/app/administration/src/main.ts
@@ -1,6 +1,8 @@
 import './component/itb-configurable-listing-filters-form-basics'
 import './component/itb-configurable-listing-filters-form-multi-select'
 import './component/itb-configurable-listing-filters-form-range'
+import './component/itb-configurable-listing-filters-form-range-interval'
+import './component/itb-configurable-listing-filters-form-range-interval-interval'
 import './mixin/itb-configurable-listing-filters-locator'
 import deDE from './module/snippet/de-DE.json';
 import enGB from './module/snippet/en-GB.json';

--- a/src/Resources/app/administration/src/mixin/itb-configurable-listing-filters-locator.ts
+++ b/src/Resources/app/administration/src/mixin/itb-configurable-listing-filters-locator.ts
@@ -1,4 +1,5 @@
 import type RepositoryFactory from "src/core/data/repository-factory.data";
+import Criteria from "@shopware-ag/admin-extension-sdk/es/data/Criteria";
 
 const { Component, Mixin } = Shopware;
 
@@ -12,6 +13,8 @@ export default Mixin.register('itbConfigurableListingFiltersLocator', Component.
                     return repositoryFactory.create('itb_listing_filter_configuration_multi_select');
                 case 'range':
                     return repositoryFactory.create('itb_listing_filter_configuration_range');
+                case 'range-interval':
+                    return repositoryFactory.create('itb_listing_filter_configuration_range_interval');
                 default:
                     throw new Error(`Invalid listing filter configuration type: ${listingFilterConfigurationType}`);
             }
@@ -25,8 +28,10 @@ export default Mixin.register('itbConfigurableListingFiltersLocator', Component.
                     return repositoryFactory.create('itb_listing_filter_configuration_multi_select');
                 case 'itb_listing_filter_configuration_range':
                     return repositoryFactory.create('itb_listing_filter_configuration_range');
+                case 'itb_listing_filter_configuration_range_interval':
+                    return repositoryFactory.create('itb_listing_filter_configuration_range_interval');
                 default:
-                    throw new Error(`Invalid listing filter configuration type: ${listingFilterConfigurationType}`);
+                    throw new Error(`Invalid entity name: ${listingFilterConfigurationType}`);
             }
         },
 
@@ -38,6 +43,8 @@ export default Mixin.register('itbConfigurableListingFiltersLocator', Component.
                     return '@Storefront/storefront/component/listing/filter/filter-multi-select.html.twig';
                 case 'range':
                     return '@Storefront/storefront/component/listing/filter/filter-range.html.twig';
+                case 'range-interval':
+                    return '@Storefront/storefront/component/listing/filter/filter-multi-select.html.twig';
                 default:
                     throw new Error(`Invalid listing filter configuration type: ${listingFilterConfigurationType}`);
             }
@@ -51,6 +58,8 @@ export default Mixin.register('itbConfigurableListingFiltersLocator', Component.
                     return 'itb-configurable-listing-filters.form.multiSelect.createPageTitle';
                 case 'range':
                     return 'itb-configurable-listing-filters.form.range.createPageTitle';
+                case 'range-interval':
+                    return 'itb-configurable-listing-filters.form.rangeInterval.createPageTitle';
                 default:
                     throw new Error(`Invalid listing filter configuration type: ${listingFilterConfigurationType}`);
             }
@@ -64,8 +73,49 @@ export default Mixin.register('itbConfigurableListingFiltersLocator', Component.
                     return 'multi-select';
                 case 'itb_listing_filter_configuration_range':
                     return 'range';
+                case 'itb_listing_filter_configuration_range_interval':
+                    return 'range-interval';
                 default:
                     throw new Error(`Invalid entity name: ${entityName}`);
+            }
+        },
+
+        getCriteriaByFilterType: function (listingFilterConfigurationType: string) {
+            const criteria = new Criteria();
+            criteria.addAssociation('salesChannel');
+
+            switch (listingFilterConfigurationType) {
+                case 'checkbox':
+                    return criteria;
+                case 'multi-select':
+                    return criteria;
+                case 'range':
+                    return criteria;
+                case 'range-interval':
+                    criteria.addAssociation('intervals');
+                    return criteria;
+                default:
+                    throw new Error(`Invalid listing filter configuration type: ${listingFilterConfigurationType}`);
+            }
+        },
+
+        getCriteriaByEntityName: function (listingFilterConfigurationType: string) {
+            const criteria = new Criteria();
+            criteria.addAssociation('salesChannel');
+
+            switch (listingFilterConfigurationType) {
+                case 'itb_listing_filter_configuration_checkbox':
+                    return criteria;
+                case 'itb_listing_filter_configuration_multi_select':
+                    return criteria;
+                case 'itb_listing_filter_configuration_range':
+                    return criteria;
+                case 'itb_listing_filter_configuration_range_interval':
+                    criteria.addAssociation('intervals');
+                    criteria.addAssociation('intervals.rangeIntervalListingFilterConfiguration');
+                    return criteria;
+                default:
+                    throw new Error(`Invalid entity name: ${listingFilterConfigurationType}`);
             }
         }
     }

--- a/src/Resources/app/administration/src/module/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/module/snippet/de-DE.json
@@ -29,6 +29,7 @@
       "createCheckboxFilterConfigurationButton": "Für Checkbox-Filter",
       "createMultiSelectFilterConfigurationButton": "Für Multi-Select-Filter",
       "createRangeFilterConfigurationButton": "Für Range Filter",
+      "createRangeIntervalFilterConfigurationButton": "Für Range-Intervall-Filter",
       "createFilterConfigurationButton": "Filterkonfiguration erstellen"
     },
     "form": {
@@ -76,6 +77,22 @@
         "cardTitle": "Einstellungen für Range-Filter",
         "labelUnit": "Einheit",
         "placeholderUnit": "Geben Sie die Einheit ein ..."
+      },
+      "rangeInterval": {
+        "createPageTitle": "Range-Intervall-Filterkonfiguration erstellen",
+        "cardTitle": "Einstellungen für Range-Intervall-Filter",
+        "labelElementPrefix": "Element-Präfix",
+        "placeholderElementPrefix": "Geben Sie das Präfix ein ...",
+        "labelElementSuffix": "Element-Suffix",
+        "placeholderElementSuffix": "Geben Sie das Suffix ein ...",
+        "interval": {
+          "cardTitle": "Intervalle",
+          "buttonAddInterval": "Intervall hinzufügen",
+          "buttonDeleteInterval": "Intervall löschen",
+          "labelMin": "Mindestwert",
+          "labelMax": "Maximalwert",
+          "labelPosition": "Position"
+        }
       }
     }
   }

--- a/src/Resources/app/administration/src/module/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/module/snippet/en-GB.json
@@ -29,6 +29,7 @@
             "createCheckboxFilterConfigurationButton": "For Checkbox Filter",
             "createMultiSelectFilterConfigurationButton": "For Multi Select Filter",
             "createRangeFilterConfigurationButton": "For Range Filter",
+            "createRangeIntervalFilterConfigurationButton": "For Range Interval Filter",
             "createFilterConfigurationButton": "Create Filter Configuration"
         },
         "form": {
@@ -76,6 +77,22 @@
                 "cardTitle": "Range Filter Settings",
                 "labelUnit": "Unit",
                 "placeholderUnit": "Enter the unit ..."
+            },
+            "rangeInterval": {
+                "createPageTitle": "Create Range Interval Filter Configuration",
+                "cardTitle": "Range Interval Filter Settings",
+                "labelElementPrefix": "Element prefix",
+                "placeholderElementPrefix": "Enter the prefix ...",
+                "labelElementSuffix": "Element suffix",
+                "placeholderElementSuffix": "Enter the suffix ...",
+                "interval": {
+                    "cardTitle": "Intervals",
+                    "buttonAddInterval": "Add interval",
+                    "buttonDeleteInterval": "Delete interval",
+                    "labelMin": "Minimum value",
+                    "labelMax": "Maximum value",
+                    "labelPosition": "Position"
+                }
             }
         }
     }

--- a/src/Resources/app/administration/src/page/itb-configurable-listing-filters-edit/index.ts
+++ b/src/Resources/app/administration/src/page/itb-configurable-listing-filters-edit/index.ts
@@ -24,7 +24,8 @@ Shopware.Component.register('itb-configurable-listing-filters-edit', {
         listingFilterConfiguration: (
             EntitySchema.itb_listing_filter_configuration_checkbox |
             EntitySchema.itb_listing_filter_configuration_multi_select |
-            EntitySchema.itb_listing_filter_configuration_range
+            EntitySchema.itb_listing_filter_configuration_range |
+            EntitySchema.itb_listing_filter_configuration_range_interval
             ) & Entity<any> | null;
         salesChannels: Array<EntitySchema.sales_channel>;
         languageId: string | null;
@@ -99,7 +100,11 @@ Shopware.Component.register('itb-configurable-listing-filters-edit', {
         },
 
         async loadListingFilterConfiguration(): Promise<void> {
-            return this.listingFilterConfigurationRepository.get(this.$route.params.id).then(result => {
+            return this.listingFilterConfigurationRepository.get(
+                this.$route.params.id,
+                undefined,
+                this.getCriteriaByFilterType(this.$route.params.type),
+            ).then(result => {
                 this.listingFilterConfiguration = result;
             })
         },

--- a/src/Resources/app/administration/src/page/itb-configurable-listing-filters-edit/itb-configurable-listing-filters-edit.html.twig
+++ b/src/Resources/app/administration/src/page/itb-configurable-listing-filters-edit/itb-configurable-listing-filters-edit.html.twig
@@ -87,6 +87,32 @@
                     </itb-configurable-listing-filters-form-range>
                 </sw-card>
                 {% endblock %}
+
+                <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                {% block itb_configurable_listing_filters_edit_form_range_interval %}
+                <sw-card
+                    :title="$tc('itb-configurable-listing-filters.form.rangeInterval.cardTitle')"
+                    position-identifier="sw-customer-create-base-form"
+                    v-if="$route.params.type === 'range-interval'"
+                >
+                    <itb-configurable-listing-filters-form-range-interval
+                        :listingFilterConfiguration="listingFilterConfiguration">
+                    </itb-configurable-listing-filters-form-range-interval>
+                </sw-card>
+                {% endblock %}
+
+                <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                {% block itb_configurable_listing_filters_edit_form_range_interval_interval %}
+                <sw-card
+                    :title="$tc('itb-configurable-listing-filters.form.rangeInterval.interval.cardTitle')"
+                    position-identifier="sw-customer-create-base-form2"
+                    v-if="$route.params.type === 'range-interval'"
+                >
+                    <itb-configurable-listing-filters-form-range-interval-interval
+                        :listingFilterConfiguration="listingFilterConfiguration">
+                    </itb-configurable-listing-filters-form-range-interval-interval>
+                </sw-card>
+                {% endblock %}
             </template>
         </sw-card-view>
     </template>

--- a/src/Resources/app/administration/src/page/itb-configurable-listing-filters-list/index.ts
+++ b/src/Resources/app/administration/src/page/itb-configurable-listing-filters-list/index.ts
@@ -43,6 +43,7 @@ Shopware.Component.register('itb-configurable-listing-filters-list', {
         checkboxListingFilterConfigurations: Array<EntitySchema.itb_listing_filter_configuration_checkbox>;
         multiSelectListingFilterConfigurations: Array<EntitySchema.itb_listing_filter_configuration_multi_select>;
         rangeListingFilterConfigurations: Array<EntitySchema.itb_listing_filter_configuration_range>;
+        rangeIntervalListingFilterConfigurations: Array<EntitySchema.itb_listing_filter_configuration_range_interval>;
         salesChannels: Array<EntitySchema.sales_channel>;
         selectedSalesChannelForFiltering: string | null;
     } {
@@ -51,6 +52,7 @@ Shopware.Component.register('itb-configurable-listing-filters-list', {
             checkboxListingFilterConfigurations: [],
             multiSelectListingFilterConfigurations: [],
             rangeListingFilterConfigurations: [],
+            rangeIntervalListingFilterConfigurations: [],
             salesChannels: [],
             selectedSalesChannelForFiltering: null,
         };
@@ -104,18 +106,12 @@ Shopware.Component.register('itb-configurable-listing-filters-list', {
             return criteria;
         },
 
-        listingFilterConfigurationCriteria(): Criteria {
-            const criteria = new Criteria();
-            criteria.addAssociation('salesChannel');
-
-            return criteria;
-        },
-
         listingFilterConfigurations(): Array<ItbConfigurableListingFilters.ListingFilterConfiguration> {
            return [
                 ...this.checkboxListingFilterConfigurations,
                 ...this.multiSelectListingFilterConfigurations,
                 ...this.rangeListingFilterConfigurations,
+                ...this.rangeIntervalListingFilterConfigurations
             ];
         },
 
@@ -196,7 +192,8 @@ Shopware.Component.register('itb-configurable-listing-filters-list', {
             const promises: Array<Promise<void>> = [];
 
             const checkboxListingFilterConfigurationRepository = this.getRepositoryByEntityName('itb_listing_filter_configuration_checkbox', this.repositoryFactory);
-            promises.push(checkboxListingFilterConfigurationRepository.search(this.listingFilterConfigurationCriteria).then(result => {
+            const checkboxListingFilterConfigurationCriteria = this.getCriteriaByEntityName('itb_listing_filter_configuration_checkbox');
+            promises.push(checkboxListingFilterConfigurationRepository.search(checkboxListingFilterConfigurationCriteria).then(result => {
                 this.checkboxListingFilterConfigurations = [];
                 result.forEach((listingFilterConfiguration) => {
                     this.checkboxListingFilterConfigurations.push(listingFilterConfiguration);
@@ -204,7 +201,8 @@ Shopware.Component.register('itb-configurable-listing-filters-list', {
             }));
 
             const multiSelectListingFilterConfigurationRepository = this.getRepositoryByEntityName('itb_listing_filter_configuration_multi_select', this.repositoryFactory);
-            promises.push(multiSelectListingFilterConfigurationRepository.search(this.listingFilterConfigurationCriteria).then(result => {
+            const multiSelectListingFilterConfigurationCriteria = this.getCriteriaByEntityName('itb_listing_filter_configuration_multi_select');
+            promises.push(multiSelectListingFilterConfigurationRepository.search(multiSelectListingFilterConfigurationCriteria).then(result => {
                 this.multiSelectListingFilterConfigurations = [];
                 result.forEach((listingFilterConfiguration) => {
                     this.multiSelectListingFilterConfigurations.push(listingFilterConfiguration);
@@ -212,10 +210,20 @@ Shopware.Component.register('itb-configurable-listing-filters-list', {
             }));
 
             const rangeListingFilterConfigurationRepository = this.getRepositoryByEntityName('itb_listing_filter_configuration_range', this.repositoryFactory);
-            promises.push(rangeListingFilterConfigurationRepository.search(this.listingFilterConfigurationCriteria).then(result => {
+            const rangeListingFilterConfigurationCriteria = this.getCriteriaByEntityName('itb_listing_filter_configuration_range');
+            promises.push(rangeListingFilterConfigurationRepository.search(rangeListingFilterConfigurationCriteria).then(result => {
                 this.rangeListingFilterConfigurations = [];
                 result.forEach((listingFilterConfiguration) => {
                     this.rangeListingFilterConfigurations.push(listingFilterConfiguration);
+                })
+            }));
+
+            const rangeIntervalListingFilterConfigurationRepository = this.getRepositoryByEntityName('itb_listing_filter_configuration_range_interval', this.repositoryFactory);
+            const rangeIntervalListingFilterConfigurationCriteria = this.getCriteriaByEntityName('itb_listing_filter_configuration_range_interval');
+            promises.push(rangeIntervalListingFilterConfigurationRepository.search(rangeIntervalListingFilterConfigurationCriteria).then(result => {
+                this.rangeIntervalListingFilterConfigurations = [];
+                result.forEach((listingFilterConfiguration) => {
+                    this.rangeIntervalListingFilterConfigurations.push(listingFilterConfiguration);
                 })
             }));
             

--- a/src/Resources/app/administration/src/page/itb-configurable-listing-filters-list/itb-configurable-listing-filters-list.html.twig
+++ b/src/Resources/app/administration/src/page/itb-configurable-listing-filters-list/itb-configurable-listing-filters-list.html.twig
@@ -28,6 +28,10 @@
                         <sw-context-menu-item @click="$router.push({name: 'itb.configurable-listing-filters.create', params: { type: 'range' }})">
                             {{ $tc('itb-configurable-listing-filters.list.createRangeFilterConfigurationButton') }}
                         </sw-context-menu-item>
+
+                        <sw-context-menu-item @click="$router.push({name: 'itb.configurable-listing-filters.create', params: { type: 'range-interval' }})">
+                            {{ $tc('itb-configurable-listing-filters.list.createRangeIntervalFilterConfigurationButton') }}
+                        </sw-context-menu-item>
                     </sw-context-button>
                 </sw-button-group>
             </template>

--- a/src/Resources/app/administration/src/types/entity.ts
+++ b/src/Resources/app/administration/src/types/entity.ts
@@ -19,6 +19,8 @@ declare namespace EntitySchema {
         itb_listing_filter_configuration_checkbox: itb_listing_filter_configuration_checkbox,
         itb_listing_filter_configuration_multi_select: itb_listing_filter_configuration_multi_select,
         itb_listing_filter_configuration_range: itb_listing_filter_configuration_range,
+        itb_listing_filter_configuration_range_interval: itb_listing_filter_configuration_range_interval,
+        itb_listing_filter_configuration_range_interval_interval: itb_listing_filter_configuration_range_interval_interval,
     }
 
     interface itb_listing_filter_configuration_checkbox extends ItbConfigurableListingFilters.ListingFilterConfiguration {
@@ -41,5 +43,19 @@ declare namespace EntitySchema {
         minLabel: string | null;
         maxLabel: string | null;
         unit: string;
+    }
+
+    interface itb_listing_filter_configuration_range_interval extends ItbConfigurableListingFilters.ListingFilterConfiguration {
+        elementPrefix: string | null;
+        elementSuffix: string | null;
+        intervals: Array<itb_listing_filter_configuration_range_interval_interval>;
+    }
+
+    interface itb_listing_filter_configuration_range_interval_interval {
+        id: string;
+        min: number | null;
+        max: number | null;
+        position: number;
+        rangeIntervalListingFilterConfigurationId: string;
     }
 }

--- a/tests/PHPUnit/Integration/EntityDefinitionRegistrationTest.php
+++ b/tests/PHPUnit/Integration/EntityDefinitionRegistrationTest.php
@@ -6,8 +6,12 @@ namespace ITB\ITBConfigurableListingFilters\Test\PHPUnit\Integration;
 
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\Checkbox\Aggregate\CheckboxListingFilterConfigurationTranslationDefinition;
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\Checkbox\CheckboxListingFilterConfigurationDefinition;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\MultiSelect\Aggregate\MultiSelectListingFilterConfigurationTranslationDefinition;
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\MultiSelect\MultiSelectListingFilterConfigurationDefinition;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\Range\Aggregate\RangeListingFilterConfigurationTranslationDefinition;
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\Range\RangeListingFilterConfigurationDefinition;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationTranslationDefinition;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationDefinition;
 use ITB\ITBConfigurableListingFilters\Test\PHPUnit\Integration\TestKernel\TestKernel;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
@@ -57,22 +61,40 @@ final class EntityDefinitionRegistrationTest extends AbstractIntegrationTestCase
         $this->assertCount(18, $multiselectListingFilterConfigurationDefinition->getFields());
 
         $multiselectListingFilterConfigurationTranslationDefinition = $registry->getByEntityName(
-            MultiSelectListingFilterConfigurationDefinition::ENTITY_NAME
+            MultiSelectListingFilterConfigurationTranslationDefinition::ENTITY_NAME
         );
         $this->assertInstanceOf(
-            MultiSelectListingFilterConfigurationDefinition::class,
+            MultiSelectListingFilterConfigurationTranslationDefinition::class,
             $multiselectListingFilterConfigurationTranslationDefinition
         );
-        $this->assertCount(18, $multiselectListingFilterConfigurationTranslationDefinition->getFields());
+        $this->assertCount(12, $multiselectListingFilterConfigurationTranslationDefinition->getFields());
 
         $rangeListingFilterConfigurationDefinition = $registry->getByEntityName(RangeListingFilterConfigurationDefinition::ENTITY_NAME);
         $this->assertInstanceOf(RangeListingFilterConfigurationDefinition::class, $rangeListingFilterConfigurationDefinition);
         $this->assertCount(13, $rangeListingFilterConfigurationDefinition->getFields());
 
         $rangeListingFilterConfigurationTranslationDefinition = $registry->getByEntityName(
-            RangeListingFilterConfigurationDefinition::ENTITY_NAME
+            RangeListingFilterConfigurationTranslationDefinition::ENTITY_NAME
         );
-        $this->assertInstanceOf(RangeListingFilterConfigurationDefinition::class, $rangeListingFilterConfigurationTranslationDefinition);
-        $this->assertCount(13, $rangeListingFilterConfigurationTranslationDefinition->getFields());
+        $this->assertInstanceOf(
+            RangeListingFilterConfigurationTranslationDefinition::class,
+            $rangeListingFilterConfigurationTranslationDefinition
+        );
+        $this->assertCount(8, $rangeListingFilterConfigurationTranslationDefinition->getFields());
+
+        $rangeListingFilterConfigurationDefinition = $registry->getByEntityName(
+            RangeIntervalListingFilterConfigurationDefinition::ENTITY_NAME
+        );
+        $this->assertInstanceOf(RangeIntervalListingFilterConfigurationDefinition::class, $rangeListingFilterConfigurationDefinition);
+        $this->assertCount(15, $rangeListingFilterConfigurationDefinition->getFields());
+
+        $rangeIntervalListingFilterConfigurationTranslationDefinition = $registry->getByEntityName(
+            RangeIntervalListingFilterConfigurationTranslationDefinition::ENTITY_NAME
+        );
+        $this->assertInstanceOf(
+            RangeIntervalListingFilterConfigurationTranslationDefinition::class,
+            $rangeIntervalListingFilterConfigurationTranslationDefinition
+        );
+        $this->assertCount(9, $rangeIntervalListingFilterConfigurationTranslationDefinition->getFields());
     }
 }

--- a/tests/PHPUnit/Unit/Core/Content/Cms/Service/RenderDataCollectionBuilderTest.php
+++ b/tests/PHPUnit/Unit/Core/Content/Cms/Service/RenderDataCollectionBuilderTest.php
@@ -75,7 +75,14 @@ final class RenderDataCollectionBuilderTest extends TestCase
         $rangeIntervalListingFilterConfigurationCollection = new RangeIntervalListingFilterConfigurationCollection([
             $rangeIntervalListingFilterConfiguration,
         ]);
-        $rangeIntervalRenderData = new MultiSelectRenderData('template', 'range-interval', 'label', 'paramenter', [], 'tooltip');
+        $rangeIntervalRenderData = new MultiSelectRenderData(
+            'template',
+            'range-interval',
+            'label',
+            'parameter',
+            new ElementCollection([], []),
+            'tooltip'
+        );
 
         $listingFilterConfigurationCollection = new ListingFilterConfigurationCollection(
             $checkboxListingFilterConfigurationCollection,

--- a/tests/PHPUnit/Unit/Core/Content/Cms/Service/RenderDataCollectionBuilderTest.php
+++ b/tests/PHPUnit/Unit/Core/Content/Cms/Service/RenderDataCollectionBuilderTest.php
@@ -12,6 +12,8 @@ use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\Mu
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\MultiSelect\MultiSelectListingFilterConfigurationEntity;
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\Range\RangeListingFilterConfigurationCollection;
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\Range\RangeListingFilterConfigurationEntity;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationCollection;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
 use ITB\ITBConfigurableListingFilters\ListingFilter\Checkbox\Storefront\RenderData as CheckboxRenderData;
 use ITB\ITBConfigurableListingFilters\ListingFilter\Checkbox\Storefront\RenderDataBuilderInterface as CheckboxRenderDataBuilder;
 use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Storefront\ElementCollection;
@@ -19,6 +21,7 @@ use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Storefront\Rende
 use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Storefront\RenderDataBuilderInterface as MultiSelectRenderDataBuilder;
 use ITB\ITBConfigurableListingFilters\ListingFilter\Range\Storefront\RenderData as RangeRenderData;
 use ITB\ITBConfigurableListingFilters\ListingFilter\Range\Storefront\RenderDataBuilderInterface as RangeRenderDataBuilder;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefront\RenderDataBuilderInterface as RangeIntervalRenderDataBuilder;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -64,10 +67,21 @@ final class RenderDataCollectionBuilderTest extends TestCase
         $rangeListingFilterConfigurationCollection = new RangeListingFilterConfigurationCollection([$rangeListingFilterConfiguration]);
         $rangeRenderData = new RangeRenderData('template', 'range', 'label', 'paramenter', 'paramenter', null, null, null, 'tooltip');
 
+        $rangeIntervalListingFilterConfiguration = new RangeIntervalListingFilterConfigurationEntity();
+        $rangeIntervalListingFilterConfiguration->setUniqueIdentifier('range-interval');
+        $rangeIntervalListingFilterConfiguration->setDalField('range-interval');
+        $rangeIntervalListingFilterConfiguration->setEnabled(true);
+
+        $rangeIntervalListingFilterConfigurationCollection = new RangeIntervalListingFilterConfigurationCollection([
+            $rangeIntervalListingFilterConfiguration,
+        ]);
+        $rangeIntervalRenderData = new MultiSelectRenderData('template', 'range-interval', 'label', 'paramenter', [], 'tooltip');
+
         $listingFilterConfigurationCollection = new ListingFilterConfigurationCollection(
             $checkboxListingFilterConfigurationCollection,
             $multiSelectListingFilterConfigurationCollection,
             $rangeListingFilterConfigurationCollection,
+            $rangeIntervalListingFilterConfigurationCollection,
         );
 
         yield 'with enabled configurations' => [
@@ -76,7 +90,8 @@ final class RenderDataCollectionBuilderTest extends TestCase
             $checkboxRenderData,
             $multiSelectRenderData,
             $rangeRenderData,
-            [$checkboxRenderData, $multiSelectRenderData, $rangeRenderData],
+            $rangeIntervalRenderData,
+            [$checkboxRenderData, $multiSelectRenderData, $rangeRenderData, $rangeIntervalRenderData],
         ];
 
         $checkboxListingFilterConfiguration = new CheckboxListingFilterConfigurationEntity();
@@ -104,10 +119,20 @@ final class RenderDataCollectionBuilderTest extends TestCase
 
         $rangeListingFilterConfigurationCollection = new RangeListingFilterConfigurationCollection([$rangeListingFilterConfiguration]);
 
+        $rangeIntervalListingFilterConfiguration = new RangeIntervalListingFilterConfigurationEntity();
+        $rangeIntervalListingFilterConfiguration->setUniqueIdentifier('range-interval');
+        $rangeIntervalListingFilterConfiguration->setDalField('range-interval');
+        $rangeIntervalListingFilterConfiguration->setEnabled(false);
+
+        $rangeIntervalListingFilterConfigurationCollection = new RangeIntervalListingFilterConfigurationCollection([
+            $rangeIntervalListingFilterConfiguration,
+        ]);
+
         $listingFilterConfigurationCollection = new ListingFilterConfigurationCollection(
             $checkboxListingFilterConfigurationCollection,
             $multiSelectListingFilterConfigurationCollection,
             $rangeListingFilterConfigurationCollection,
+            $rangeIntervalListingFilterConfigurationCollection,
         );
 
         yield 'with disabled configurations' => [
@@ -116,6 +141,7 @@ final class RenderDataCollectionBuilderTest extends TestCase
             $checkboxRenderData,
             $multiSelectRenderData,
             $rangeRenderData,
+            $rangeIntervalRenderData,
             [],
         ];
     }
@@ -130,6 +156,7 @@ final class RenderDataCollectionBuilderTest extends TestCase
         CheckboxRenderData $checkboxRenderData,
         MultiSelectRenderData $multiSelectRenderData,
         RangeRenderData $rangeRenderData,
+        MultiSelectRenderData $rangeIntervalSelectRenderData,
         array $expectedRenderDatasets,
     ): void {
         $checkboxRenderDataBuilder = $this->createMock(CheckboxRenderDataBuilder::class);
@@ -141,11 +168,15 @@ final class RenderDataCollectionBuilderTest extends TestCase
         $rangeRenderDataBuilder = $this->createMock(RangeRenderDataBuilder::class);
         $rangeRenderDataBuilder->method('buildRenderData')
             ->willReturn($rangeRenderData);
+        $rangeIntervalRenderDataBuilder = $this->createMock(RangeIntervalRenderDataBuilder::class);
+        $rangeIntervalRenderDataBuilder->method('buildRenderData')
+            ->willReturn($rangeIntervalSelectRenderData);
 
         $renderDataCollectionBuilder = new RenderDataCollectionBuilder(
             $checkboxRenderDataBuilder,
             $multiSelectRenderDataBuilder,
-            $rangeRenderDataBuilder
+            $rangeRenderDataBuilder,
+            $rangeIntervalRenderDataBuilder
         );
 
         $renderDataCollection = $renderDataCollectionBuilder->buildRenderDataCollection(

--- a/tests/PHPUnit/Unit/Core/Content/ListingFilterConfiguration/ListingFilterConfigurationCollectionTest.php
+++ b/tests/PHPUnit/Unit/Core/Content/ListingFilterConfiguration/ListingFilterConfigurationCollectionTest.php
@@ -11,6 +11,8 @@ use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\Mu
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\MultiSelect\MultiSelectListingFilterConfigurationEntity;
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\Range\RangeListingFilterConfigurationCollection;
 use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\Range\RangeListingFilterConfigurationEntity;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationCollection;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -22,8 +24,14 @@ final class ListingFilterConfigurationCollectionTest extends TestCase
         $checkboxCollection = new CheckboxListingFilterConfigurationCollection();
         $multiSelectCollection = new MultiSelectListingFilterConfigurationCollection();
         $rangeCollection = new RangeListingFilterConfigurationCollection();
+        $rangeIntervalCollection = new RangeIntervalListingFilterConfigurationCollection();
 
-        $collection = new ListingFilterConfigurationCollection($checkboxCollection, $multiSelectCollection, $rangeCollection);
+        $collection = new ListingFilterConfigurationCollection(
+            $checkboxCollection,
+            $multiSelectCollection,
+            $rangeCollection,
+            $rangeIntervalCollection
+        );
 
         $iterator = $collection->getIterator();
         $this->assertInstanceOf(\ArrayIterator::class, $iterator);
@@ -35,6 +43,7 @@ final class ListingFilterConfigurationCollectionTest extends TestCase
         $checkboxCollection = new CheckboxListingFilterConfigurationCollection();
         $multiSelectCollection = new MultiSelectListingFilterConfigurationCollection();
         $rangeCollection = new RangeListingFilterConfigurationCollection();
+        $rangeIntervalCollection = new RangeIntervalListingFilterConfigurationCollection();
 
         $checkboxEntity = new CheckboxListingFilterConfigurationEntity();
         $checkboxEntity->setUniqueIdentifier('checkbox');
@@ -51,15 +60,26 @@ final class ListingFilterConfigurationCollectionTest extends TestCase
         $rangeEntity->setDalField('rangeField');
         $rangeEntity->setPosition(3);
 
+        $rangeIntervalEntity = new RangeIntervalListingFilterConfigurationEntity();
+        $rangeIntervalEntity->setUniqueIdentifier('rangeInterval');
+        $rangeIntervalEntity->setDalField('rangeIntervalField');
+        $rangeIntervalEntity->setPosition(4);
+
         $checkboxCollection->add($checkboxEntity);
         $multiSelectCollection->add($multiSelectEntity);
         $rangeCollection->add($rangeEntity);
+        $rangeIntervalCollection->add($rangeIntervalEntity);
 
-        $collection = new ListingFilterConfigurationCollection($checkboxCollection, $multiSelectCollection, $rangeCollection);
+        $collection = new ListingFilterConfigurationCollection(
+            $checkboxCollection,
+            $multiSelectCollection,
+            $rangeCollection,
+            $rangeIntervalCollection
+        );
 
         $result = $collection->getListingFilterConfigurations();
 
-        $this->assertCount(3, $result);
+        $this->assertCount(4, $result);
         $this->assertEquals($multiSelectEntity, $result[0]);
         $this->assertEquals($checkboxEntity, $result[1]);
         $this->assertEquals($rangeEntity, $result[2]);
@@ -70,6 +90,7 @@ final class ListingFilterConfigurationCollectionTest extends TestCase
         $checkboxCollection = new CheckboxListingFilterConfigurationCollection();
         $multiSelectCollection = new MultiSelectListingFilterConfigurationCollection();
         $rangeCollection = new RangeListingFilterConfigurationCollection();
+        $rangeIntervalCollection = new RangeIntervalListingFilterConfigurationCollection();
 
         $checkboxEntity = new CheckboxListingFilterConfigurationEntity();
         $checkboxEntity->setUniqueIdentifier('bField');
@@ -84,7 +105,12 @@ final class ListingFilterConfigurationCollectionTest extends TestCase
         $checkboxCollection->add($checkboxEntity);
         $multiSelectCollection->add($multiSelectEntity);
 
-        $collection = new ListingFilterConfigurationCollection($checkboxCollection, $multiSelectCollection, $rangeCollection);
+        $collection = new ListingFilterConfigurationCollection(
+            $checkboxCollection,
+            $multiSelectCollection,
+            $rangeCollection,
+            $rangeIntervalCollection
+        );
 
         $result = $collection->getListingFilterConfigurations();
 
@@ -98,6 +124,7 @@ final class ListingFilterConfigurationCollectionTest extends TestCase
         $checkboxCollection = new CheckboxListingFilterConfigurationCollection();
         $multiSelectCollection = new MultiSelectListingFilterConfigurationCollection();
         $rangeCollection = new RangeListingFilterConfigurationCollection();
+        $rangeIntervalCollection = new RangeIntervalListingFilterConfigurationCollection();
 
         $checkboxEntity = new CheckboxListingFilterConfigurationEntity();
         $checkboxEntity->setUniqueIdentifier('checkboxField');
@@ -114,15 +141,26 @@ final class ListingFilterConfigurationCollectionTest extends TestCase
         $rangeEntity->setDalField('rangeField');
         $rangeEntity->setPosition(null);
 
+        $rangeIntervalEntity = new RangeIntervalListingFilterConfigurationEntity();
+        $rangeIntervalEntity->setUniqueIdentifier('rangeIntervalField');
+        $rangeIntervalEntity->setDalField('rangeIntervalField');
+        $rangeIntervalEntity->setPosition(2);
+
         $checkboxCollection->add($checkboxEntity);
         $multiSelectCollection->add($multiSelectEntity);
         $rangeCollection->add($rangeEntity);
+        $rangeIntervalCollection->add($rangeIntervalEntity);
 
-        $collection = new ListingFilterConfigurationCollection($checkboxCollection, $multiSelectCollection, $rangeCollection);
+        $collection = new ListingFilterConfigurationCollection(
+            $checkboxCollection,
+            $multiSelectCollection,
+            $rangeCollection,
+            $rangeIntervalCollection
+        );
 
         $result = $collection->getListingFilterConfigurations();
 
-        $this->assertCount(3, $result);
+        $this->assertCount(4, $result);
         $this->assertEquals($multiSelectEntity, $result[0]);
     }
 }

--- a/tests/PHPUnit/Unit/Core/Content/ListingFilterConfiguration/RangeInterval/Aggregate/RangeIntervalListingFilterConfigurationIntervalCollectionTest.php
+++ b/tests/PHPUnit/Unit/Core/Content/ListingFilterConfiguration/RangeInterval/Aggregate/RangeIntervalListingFilterConfigurationIntervalCollectionTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\Test\PHPUnit\Unit\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalCollection;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalEntity;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RangeIntervalListingFilterConfigurationIntervalCollection::class)]
+final class RangeIntervalListingFilterConfigurationIntervalCollectionTest extends TestCase
+{
+    public function testGetApiAlias(): void
+    {
+        $collection = new RangeIntervalListingFilterConfigurationIntervalCollection();
+
+        $this->assertSame('itb_listing_filter_configuration_collection_range_interval_interval', $collection->getApiAlias());
+    }
+
+    public function testGetElementsSortedByPosition(): void
+    {
+        $collection = new RangeIntervalListingFilterConfigurationIntervalCollection();
+
+        $interval1 = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval1->setId('interval-1');
+        $interval1->setPosition(3);
+
+        $interval2 = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval2->setId('interval-2');
+        $interval2->setPosition(1);
+
+        $interval3 = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval3->setId('interval-3');
+        $interval3->setPosition(2);
+
+        $collection->add($interval1);
+        $collection->add($interval2);
+        $collection->add($interval3);
+
+        $sortedElements = $collection->getElementsSortedByPosition();
+
+        $this->assertCount(3, $sortedElements);
+        $this->assertSame($interval2, $sortedElements[0]); // Position 1
+        $this->assertSame($interval3, $sortedElements[1]); // Position 2
+        $this->assertSame($interval1, $sortedElements[2]); // Position 3
+    }
+
+    public function testGetElementsSortedWithSamePosition(): void
+    {
+        $collection = new RangeIntervalListingFilterConfigurationIntervalCollection();
+
+        $interval1 = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval1->setId('interval-1');
+        $interval1->setPosition(1);
+
+        $interval2 = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval2->setId('interval-2');
+        $interval2->setPosition(1); // Same position
+
+        $collection->add($interval1);
+        $collection->add($interval2);
+
+        $sortedElements = $collection->getElementsSortedByPosition();
+
+        $this->assertCount(2, $sortedElements);
+        // The order is not guaranteed to be specific for same positions
+    }
+
+    public function testGetExpectedClass(): void
+    {
+        $collection = new RangeIntervalListingFilterConfigurationIntervalCollection();
+
+        $reflectionClass = new \ReflectionClass(RangeIntervalListingFilterConfigurationIntervalCollection::class);
+        $method = $reflectionClass->getMethod('getExpectedClass');
+
+        $this->assertSame(RangeIntervalListingFilterConfigurationIntervalEntity::class, $method->invoke($collection));
+    }
+
+    public function testGetIterator(): void
+    {
+        $collection = new RangeIntervalListingFilterConfigurationIntervalCollection();
+
+        $interval1 = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval1->setId('interval-1');
+        $interval1->setPosition(3);
+
+        $interval2 = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval2->setId('interval-2');
+        $interval2->setPosition(1);
+
+        $interval3 = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval3->setId('interval-3');
+        $interval3->setPosition(2);
+
+        $collection->add($interval1);
+        $collection->add($interval2);
+        $collection->add($interval3);
+
+        $iterations = 0;
+        $ids = [];
+
+        foreach ($collection as $item) {
+            $iterations++;
+            $ids[] = $item->getId();
+        }
+
+        $this->assertSame(3, $iterations);
+        $this->assertSame(['interval-2', 'interval-3', 'interval-1'], $ids);
+    }
+}

--- a/tests/PHPUnit/Unit/Core/Content/ListingFilterConfiguration/RangeInterval/Aggregate/RangeIntervalListingFilterConfigurationIntervalDefinitionTest.php
+++ b/tests/PHPUnit/Unit/Core/Content/ListingFilterConfiguration/RangeInterval/Aggregate/RangeIntervalListingFilterConfigurationIntervalDefinitionTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\Test\PHPUnit\Unit\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalCollection;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalDefinition;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalEntity;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationDefinition;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
+
+#[CoversClass(RangeIntervalListingFilterConfigurationIntervalDefinition::class)]
+final class RangeIntervalListingFilterConfigurationIntervalDefinitionTest extends TestCase
+{
+    private RangeIntervalListingFilterConfigurationIntervalDefinition $definition;
+
+    protected function setUp(): void
+    {
+        $this->definition = new RangeIntervalListingFilterConfigurationIntervalDefinition();
+    }
+
+    public function testDefineFieldsWithoutAssociations(): void
+    {
+        $registry = $this->createStub(DefinitionInstanceRegistry::class);
+        $this->definition->compile($registry);
+        $fields = $this->definition->getFields();
+
+        $this->assertTrue($fields->has('id'));
+        $idField = $fields->get('id');
+        $this->assertInstanceOf(IdField::class, $idField);
+        $this->assertTrue($idField->is(Required::class));
+        $this->assertTrue($idField->is(ApiAware::class));
+        $this->assertTrue($idField->is(PrimaryKey::class));
+
+        $this->assertTrue($fields->has('min'));
+        $minField = $fields->get('min');
+        $this->assertInstanceOf(IntField::class, $minField);
+        $this->assertTrue($minField->is(ApiAware::class));
+
+        $this->assertTrue($fields->has('max'));
+        $maxField = $fields->get('max');
+        $this->assertInstanceOf(IntField::class, $maxField);
+        $this->assertTrue($maxField->is(ApiAware::class));
+
+        $this->assertTrue($fields->has('position'));
+        $positionField = $fields->get('position');
+        $this->assertInstanceOf(IntField::class, $positionField);
+        $this->assertTrue($positionField->is(ApiAware::class));
+    }
+
+    public function testDefineFieldsWithRangeIntervalListingFilterAssociation(): void
+    {
+        $rangeIntervalListingFilterConfigurationDefinition = new RangeIntervalListingFilterConfigurationDefinition();
+        $registry = $this->createMock(DefinitionInstanceRegistry::class);
+        $registry->method('getByClassOrEntityName')
+            ->willReturnCallback(function (string $className) use (
+                $rangeIntervalListingFilterConfigurationDefinition
+            ): RangeIntervalListingFilterConfigurationDefinition {
+                $this->assertSame(RangeIntervalListingFilterConfigurationDefinition::class, $className);
+
+                return $rangeIntervalListingFilterConfigurationDefinition;
+            });
+        $this->definition->compile($registry);
+        $fields = $this->definition->getFields();
+
+        $this->assertTrue($fields->has('rangeIntervalListingFilterConfiguration'));
+        $associationField = $fields->get('rangeIntervalListingFilterConfiguration');
+        $this->assertInstanceOf(ManyToOneAssociationField::class, $associationField);
+
+        $fkFieldName = RangeIntervalListingFilterConfigurationDefinition::ENTITY_NAME . '_id';
+        $this->assertSame($fkFieldName, $associationField->getStorageName());
+        $this->assertSame($rangeIntervalListingFilterConfigurationDefinition, $associationField->getReferenceDefinition());
+        $this->assertSame('id', $associationField->getReferenceField());
+    }
+
+    public function testEntityName(): void
+    {
+        $this->assertSame('itb_listing_filter_configuration_range_interval_interval', $this->definition->getEntityName());
+        $this->assertSame(
+            'itb_listing_filter_configuration_range_interval_interval',
+            RangeIntervalListingFilterConfigurationIntervalDefinition::ENTITY_NAME
+        );
+    }
+
+    public function testGetCollectionClass(): void
+    {
+        $this->assertSame(RangeIntervalListingFilterConfigurationIntervalCollection::class, $this->definition->getCollectionClass());
+    }
+
+    public function testGetEntityClass(): void
+    {
+        $this->assertSame(RangeIntervalListingFilterConfigurationIntervalEntity::class, $this->definition->getEntityClass());
+    }
+
+    public function testGetParentDefinitionClass(): void
+    {
+        // Use reflection to access protected method
+        $reflectionClass = new \ReflectionClass(RangeIntervalListingFilterConfigurationIntervalDefinition::class);
+        $method = $reflectionClass->getMethod('getParentDefinitionClass');
+        $method->setAccessible(true);
+
+        $this->assertSame(RangeIntervalListingFilterConfigurationDefinition::class, $method->invoke($this->definition));
+    }
+}

--- a/tests/PHPUnit/Unit/Core/Content/ListingFilterConfiguration/RangeInterval/Aggregate/RangeIntervalListingFilterConfigurationIntervalEntityTest.php
+++ b/tests/PHPUnit/Unit/Core/Content/ListingFilterConfiguration/RangeInterval/Aggregate/RangeIntervalListingFilterConfigurationIntervalEntityTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\Test\PHPUnit\Unit\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalEntity;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
+
+#[CoversClass(RangeIntervalListingFilterConfigurationIntervalEntity::class)]
+final class RangeIntervalListingFilterConfigurationIntervalEntityTest extends TestCase
+{
+    public static function rangeFilterDataProvider(): \Generator
+    {
+        yield 'both min and max are set' => [
+            'min' => 100,
+            'max' => 200,
+            'expectedRange' => [
+                RangeFilter::GTE => 100,
+                RangeFilter::LTE => 200,
+            ],
+        ];
+
+        yield 'only min is set' => [
+            'min' => 100,
+            'max' => null,
+            'expectedRange' => [
+                RangeFilter::GTE => 100,
+            ],
+        ];
+
+        yield 'only max is set' => [
+            'min' => null,
+            'max' => 200,
+            'expectedRange' => [
+                RangeFilter::LTE => 200,
+            ],
+        ];
+
+        yield 'both min and max are null' => [
+            'min' => null,
+            'max' => null,
+            'expectedRange' => [],
+        ];
+    }
+
+    public function testConfigurationAssociation(): void
+    {
+        $entity = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $configEntity = new RangeIntervalListingFilterConfigurationEntity();
+
+        $entity->setRangeIntervalListingFilterConfiguration($configEntity);
+
+        $this->assertSame($configEntity, $entity->getRangeIntervalListingFilterConfiguration());
+    }
+
+    public function testEntityIdTrait(): void
+    {
+        $entity = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $id = 'test-entity-id';
+
+        $reflectionClass = new \ReflectionClass($entity);
+        $property = $reflectionClass->getProperty('id');
+        $property->setValue($entity, $id);
+
+        $this->assertSame($id, $entity->getId());
+    }
+
+    public function testGetCountAggregationName(): void
+    {
+        $entity = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $configEntity = new RangeIntervalListingFilterConfigurationEntity();
+        $configEntity->setDalField('product.price');
+
+        $entity->setId('test-interval-id');
+        $entity->setRangeIntervalListingFilterConfiguration($configEntity);
+
+        $this->assertSame('product-price_test-interval-id', $entity->getCountAggregationName());
+    }
+
+    public function testGetIdFromCountAggregationName(): void
+    {
+        $entity = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $configEntity = new RangeIntervalListingFilterConfigurationEntity();
+        $configEntity->setDalField('product.price');
+
+        $entity->setRangeIntervalListingFilterConfiguration($configEntity);
+
+        $this->assertSame('test-interval-id', $entity->getIdFromCountAggregationName('product-price_test-interval-id'));
+    }
+
+    /**
+     * @param array{
+     *      gte?: int,
+     *      lte?: int
+     *  } $expectedRange
+     */
+    #[DataProvider('rangeFilterDataProvider')]
+    public function testGetRangeForFilter(?int $min, ?int $max, array $expectedRange): void
+    {
+        $entity = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $entity->setMin($min);
+        $entity->setMax($max);
+
+        $this->assertSame($expectedRange, $entity->getRangeForFilter());
+    }
+
+    public function testGetterAndSetterMethods(): void
+    {
+        $entity = new RangeIntervalListingFilterConfigurationIntervalEntity();
+
+        $min = 100;
+        $max = 200;
+        $position = 5;
+        $configId = 'test-config-id';
+
+        $entity->setMin($min);
+        $entity->setMax($max);
+        $entity->setPosition($position);
+        $entity->setRangeIntervalListingFilterConfigurationId($configId);
+
+        $this->assertSame($min, $entity->getMin());
+        $this->assertSame($max, $entity->getMax());
+        $this->assertSame($position, $entity->getPosition());
+        $this->assertSame($configId, $entity->getRangeIntervalListingFilterConfigurationId());
+    }
+}

--- a/tests/PHPUnit/Unit/Core/Content/ListingFilterConfiguration/RangeInterval/Aggregate/RangeIntervalListingFilterConfigurationTranslationCollectionTest.php
+++ b/tests/PHPUnit/Unit/Core/Content/ListingFilterConfiguration/RangeInterval/Aggregate/RangeIntervalListingFilterConfigurationTranslationCollectionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\Test\PHPUnit\Unit\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationTranslationCollection;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationTranslationEntity;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RangeIntervalListingFilterConfigurationTranslationCollection::class)]
+final class RangeIntervalListingFilterConfigurationTranslationCollectionTest extends TestCase
+{
+    public function testGetApiAlias(): void
+    {
+        $collection = new RangeIntervalListingFilterConfigurationTranslationCollection();
+
+        $this->assertSame('itb_listing_filter_configuration_translation_collection_range_interval', $collection->getApiAlias());
+    }
+
+    public function testGetExpectedClass(): void
+    {
+        $collection = new RangeIntervalListingFilterConfigurationTranslationCollection();
+
+        $reflectionClass = new \ReflectionClass(RangeIntervalListingFilterConfigurationTranslationCollection::class);
+        $method = $reflectionClass->getMethod('getExpectedClass');
+
+        $this->assertSame(RangeIntervalListingFilterConfigurationTranslationEntity::class, $method->invoke($collection));
+    }
+}

--- a/tests/PHPUnit/Unit/Core/Content/ListingFilterConfiguration/RangeInterval/Aggregate/RangeIntervalListingFilterConfigurationTranslationDefinitionTest.php
+++ b/tests/PHPUnit/Unit/Core/Content/ListingFilterConfiguration/RangeInterval/Aggregate/RangeIntervalListingFilterConfigurationTranslationDefinitionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\Test\PHPUnit\Unit\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationTranslationCollection;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationTranslationDefinition;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationTranslationEntity;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationDefinition;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+
+#[CoversClass(RangeIntervalListingFilterConfigurationTranslationDefinition::class)]
+final class RangeIntervalListingFilterConfigurationTranslationDefinitionTest extends TestCase
+{
+    private RangeIntervalListingFilterConfigurationTranslationDefinition $definition;
+
+    protected function setUp(): void
+    {
+        $this->definition = new RangeIntervalListingFilterConfigurationTranslationDefinition();
+    }
+
+    public function testDefineFieldsWithoutAssociations(): void
+    {
+        $registry = $this->createStub(DefinitionInstanceRegistry::class);
+        $this->definition->compile($registry);
+        $fields = $this->definition->getFields();
+
+        $this->assertTrue($fields->has('languageId'));
+        $this->assertTrue($fields->has('displayName'));
+
+        $this->assertTrue($fields->has('elementPrefix'));
+        $elementPrefixField = $fields->get('elementPrefix');
+        $this->assertInstanceOf(StringField::class, $elementPrefixField);
+        $this->assertTrue($elementPrefixField->is(ApiAware::class));
+
+        $this->assertTrue($fields->has('elementSuffix'));
+        $elementSuffixField = $fields->get('elementSuffix');
+        $this->assertInstanceOf(StringField::class, $elementSuffixField);
+        $this->assertTrue($elementSuffixField->is(ApiAware::class));
+    }
+
+    public function testEntityName(): void
+    {
+        $this->assertSame('itb_listing_filter_configuration_range_interval_translation', $this->definition->getEntityName());
+        $this->assertSame(
+            'itb_listing_filter_configuration_range_interval_translation',
+            RangeIntervalListingFilterConfigurationTranslationDefinition::ENTITY_NAME
+        );
+    }
+
+    public function testGetCollectionClass(): void
+    {
+        $this->assertSame(RangeIntervalListingFilterConfigurationTranslationCollection::class, $this->definition->getCollectionClass());
+    }
+
+    public function testGetEntityClass(): void
+    {
+        $this->assertSame(RangeIntervalListingFilterConfigurationTranslationEntity::class, $this->definition->getEntityClass());
+    }
+
+    public function testGetParentDefinitionClass(): void
+    {
+        $reflectionClass = new \ReflectionClass(RangeIntervalListingFilterConfigurationTranslationDefinition::class);
+        $method = $reflectionClass->getMethod('getParentDefinitionClass');
+
+        $this->assertSame(RangeIntervalListingFilterConfigurationDefinition::class, $method->invoke($this->definition));
+    }
+}

--- a/tests/PHPUnit/Unit/Core/Content/ListingFilterConfiguration/RangeInterval/Aggregate/RangeIntervalListingFilterConfigurationTranslationEntityTest.php
+++ b/tests/PHPUnit/Unit/Core/Content/ListingFilterConfiguration/RangeInterval/Aggregate/RangeIntervalListingFilterConfigurationTranslationEntityTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\Test\PHPUnit\Unit\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationTranslationEntity;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RangeIntervalListingFilterConfigurationTranslationEntity::class)]
+final class RangeIntervalListingFilterConfigurationTranslationEntityTest extends TestCase
+{
+    public function testConfigurationAssociation(): void
+    {
+        $entity = new RangeIntervalListingFilterConfigurationTranslationEntity();
+        $configEntity = new RangeIntervalListingFilterConfigurationEntity();
+
+        $entity->setRangeIntervalListingFilterConfiguration($configEntity);
+
+        $this->assertSame($configEntity, $entity->getRangeIntervalListingFilterConfiguration());
+    }
+
+    public function testGetterAndSetterMethods(): void
+    {
+        $entity = new RangeIntervalListingFilterConfigurationTranslationEntity();
+
+        $elementPrefix = '€';
+        $elementSuffix = ',-';
+        $configId = 'test-config-id';
+
+        $entity->setElementPrefix($elementPrefix);
+        $entity->setElementSuffix($elementSuffix);
+        $entity->setRangeIntervalListingFilterConfigurationId($configId);
+
+        $this->assertSame($elementPrefix, $entity->getElementPrefix());
+        $this->assertSame($elementSuffix, $entity->getElementSuffix());
+        $this->assertSame($configId, $entity->getRangeIntervalListingFilterConfigurationId());
+    }
+
+    public function testInheritanceFromListingFilterConfigurationTranslationEntity(): void
+    {
+        $entity = new RangeIntervalListingFilterConfigurationTranslationEntity();
+
+        $displayName = 'Test Display Name';
+        $entity->setDisplayName($displayName);
+
+        $this->assertSame($displayName, $entity->getDisplayName());
+    }
+
+    public function testSetNullElementPrefixAndSuffix(): void
+    {
+        $entity = new RangeIntervalListingFilterConfigurationTranslationEntity();
+
+        $entity->setElementPrefix(null);
+        $entity->setElementSuffix(null);
+
+        $this->assertNull($entity->getElementPrefix());
+        $this->assertNull($entity->getElementSuffix());
+    }
+}

--- a/tests/PHPUnit/Unit/Core/Content/ListingFilterConfiguration/RangeInterval/RangeIntervalListingFilterConfigurationCollectionTest.php
+++ b/tests/PHPUnit/Unit/Core/Content/ListingFilterConfiguration/RangeInterval/RangeIntervalListingFilterConfigurationCollectionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\Test\PHPUnit\Unit\Core\Content\ListingFilterConfiguration\RangeInterval;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationCollection;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RangeIntervalListingFilterConfigurationCollection::class)]
+final class RangeIntervalListingFilterConfigurationCollectionTest extends TestCase
+{
+    public function testGetApiAlias(): void
+    {
+        $collection = new RangeIntervalListingFilterConfigurationCollection();
+
+        $this->assertSame('itb_listing_filter_configuration_collection_range_interval', $collection->getApiAlias());
+    }
+
+    public function testGetExpectedClass(): void
+    {
+        $collection = new RangeIntervalListingFilterConfigurationCollection();
+
+        $reflectionClass = new \ReflectionClass(RangeIntervalListingFilterConfigurationCollection::class);
+        $method = $reflectionClass->getMethod('getExpectedClass');
+
+        $this->assertSame(RangeIntervalListingFilterConfigurationEntity::class, $method->invoke($collection));
+    }
+}

--- a/tests/PHPUnit/Unit/Core/Content/ListingFilterConfiguration/RangeInterval/RangeIntervalListingFilterConfigurationDefinitionTest.php
+++ b/tests/PHPUnit/Unit/Core/Content/ListingFilterConfiguration/RangeInterval/RangeIntervalListingFilterConfigurationDefinitionTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\Test\PHPUnit\Unit\Core\Content\ListingFilterConfiguration\RangeInterval;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalDefinition;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationTranslationDefinition;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationCollection;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationDefinition;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslatedField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslationsAssociationField;
+
+#[CoversClass(RangeIntervalListingFilterConfigurationDefinition::class)]
+final class RangeIntervalListingFilterConfigurationDefinitionTest extends TestCase
+{
+    private RangeIntervalListingFilterConfigurationDefinition $definition;
+
+    protected function setUp(): void
+    {
+        $this->definition = new RangeIntervalListingFilterConfigurationDefinition();
+    }
+
+    public function testDefineFieldsWithIntervalsAssociation(): void
+    {
+        $intervalDefinition = new RangeIntervalListingFilterConfigurationIntervalDefinition();
+        $registry = $this->createMock(DefinitionInstanceRegistry::class);
+        $registry->method('getByClassOrEntityName')
+            ->willReturnCallback(function (string $className) use (
+                $intervalDefinition
+            ): RangeIntervalListingFilterConfigurationIntervalDefinition {
+                $this->assertSame(RangeIntervalListingFilterConfigurationIntervalDefinition::class, $className);
+
+                return $intervalDefinition;
+            });
+        $this->definition->compile($registry);
+        $fields = $this->definition->getFields();
+
+        $this->assertTrue($fields->has('intervals'));
+        $intervalsField = $fields->get('intervals');
+        $this->assertInstanceOf(OneToManyAssociationField::class, $intervalsField);
+        $this->assertTrue($intervalsField->is(ApiAware::class));
+        $this->assertTrue($intervalsField->is(Required::class));
+
+        $this->assertSame('intervals', $intervalsField->getPropertyName());
+        $this->assertSame($intervalDefinition, $intervalsField->getReferenceDefinition());
+        $this->assertSame(RangeIntervalListingFilterConfigurationDefinition::ENTITY_NAME . '_id', $intervalsField->getReferenceField());
+    }
+
+    public function testDefineFieldsWithoutAssociations(): void
+    {
+        $registry = $this->createStub(DefinitionInstanceRegistry::class);
+        $this->definition->compile($registry);
+        $fields = $this->definition->getFields();
+
+        $this->assertTrue($fields->has('elementPrefix'));
+        $elementPrefixField = $fields->get('elementPrefix');
+        $this->assertInstanceOf(TranslatedField::class, $elementPrefixField);
+        $this->assertTrue($elementPrefixField->is(ApiAware::class));
+
+        $this->assertTrue($fields->has('elementSuffix'));
+        $elementSuffixField = $fields->get('elementSuffix');
+        $this->assertInstanceOf(TranslatedField::class, $elementSuffixField);
+        $this->assertTrue($elementSuffixField->is(ApiAware::class));
+    }
+
+    public function testDefineFieldsWithTranslationsAssociation(): void
+    {
+        $translationDefinition = new RangeIntervalListingFilterConfigurationTranslationDefinition();
+        $registry = $this->createMock(DefinitionInstanceRegistry::class);
+        $registry->method('getByClassOrEntityName')
+            ->willReturnCallback(function (string $className) use (
+                $translationDefinition
+            ): RangeIntervalListingFilterConfigurationTranslationDefinition {
+                $this->assertSame(RangeIntervalListingFilterConfigurationTranslationDefinition::class, $className);
+
+                return $translationDefinition;
+            });
+        $this->definition->compile($registry);
+        $fields = $this->definition->getFields();
+
+        $this->assertTrue($fields->has('translations'));
+        $translationsField = $fields->get('translations');
+        $this->assertInstanceOf(TranslationsAssociationField::class, $translationsField);
+        $this->assertTrue($translationsField->is(ApiAware::class));
+        $this->assertTrue($translationsField->is(Required::class));
+
+        $this->assertSame($translationDefinition, $translationsField->getReferenceDefinition());
+        $this->assertSame(RangeIntervalListingFilterConfigurationDefinition::ENTITY_NAME . '_id', $translationsField->getReferenceField());
+    }
+
+    public function testEntityName(): void
+    {
+        $this->assertSame('itb_listing_filter_configuration_range_interval', $this->definition->getEntityName());
+        $this->assertSame(
+            'itb_listing_filter_configuration_range_interval',
+            RangeIntervalListingFilterConfigurationDefinition::ENTITY_NAME
+        );
+    }
+
+    public function testGetCollectionClass(): void
+    {
+        $this->assertSame(RangeIntervalListingFilterConfigurationCollection::class, $this->definition->getCollectionClass());
+    }
+
+    public function testGetEntityClass(): void
+    {
+        $this->assertSame(RangeIntervalListingFilterConfigurationEntity::class, $this->definition->getEntityClass());
+    }
+}

--- a/tests/PHPUnit/Unit/Core/Content/ListingFilterConfiguration/RangeInterval/RangeIntervalListingFilterConfigurationEntityTest.php
+++ b/tests/PHPUnit/Unit/Core/Content/ListingFilterConfiguration/RangeInterval/RangeIntervalListingFilterConfigurationEntityTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\Test\PHPUnit\Unit\Core\Content\ListingFilterConfiguration\RangeInterval;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalCollection;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RangeIntervalListingFilterConfigurationEntity::class)]
+final class RangeIntervalListingFilterConfigurationEntityTest extends TestCase
+{
+    public static function dalFieldProvider(): \Generator
+    {
+        yield 'simple field name' => [
+            'dalField' => 'price',
+            'expectedResult' => 'price',
+        ];
+
+        yield 'camelCase field name' => [
+            'dalField' => 'productPrice',
+            'expectedResult' => 'product-price',
+        ];
+
+        yield 'field name with dots' => [
+            'dalField' => 'product.price',
+            'expectedResult' => 'product-price',
+        ];
+
+        yield 'complex field name' => [
+            'dalField' => 'product.manufacturer.name',
+            'expectedResult' => 'product-manufacturer-name',
+        ];
+    }
+
+    #[DataProvider('dalFieldProvider')]
+    public function testGetAggregationName(string $dalField, string $expectedResult): void
+    {
+        $entity = new RangeIntervalListingFilterConfigurationEntity();
+        $entity->setDalField($dalField);
+
+        $this->assertSame($expectedResult, $entity->getAggregationName());
+    }
+
+    #[DataProvider('dalFieldProvider')]
+    public function testGetFilterName(string $dalField, string $expectedResult): void
+    {
+        $entity = new RangeIntervalListingFilterConfigurationEntity();
+        $entity->setDalField($dalField);
+
+        $this->assertSame($expectedResult, $entity->getFilterName());
+    }
+
+    public function testGetterAndSetterMethods(): void
+    {
+        $entity = new RangeIntervalListingFilterConfigurationEntity();
+
+        $elementPrefix = '€';
+        $elementSuffix = ',-';
+        $intervalCollection = new RangeIntervalListingFilterConfigurationIntervalCollection();
+
+        $entity->setElementPrefix($elementPrefix);
+        $entity->setElementSuffix($elementSuffix);
+        $entity->setIntervals($intervalCollection);
+
+        $this->assertSame($elementPrefix, $entity->getElementPrefix());
+        $this->assertSame($elementSuffix, $entity->getElementSuffix());
+        $this->assertSame($intervalCollection, $entity->getIntervals());
+    }
+
+    public function testTwigTemplate(): void
+    {
+        $entity = new RangeIntervalListingFilterConfigurationEntity();
+
+        $this->assertSame('@Storefront/storefront/component/listing/filter/filter-multi-select.html.twig', $entity::TWIG_TEMPLATE);
+    }
+}

--- a/tests/PHPUnit/Unit/ListingFilter/RangeInterval/Dal/FilterBuilderForNonCompatibleFieldsTest.php
+++ b/tests/PHPUnit/Unit/ListingFilter/RangeInterval/Dal/FilterBuilderForNonCompatibleFieldsTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\Test\PHPUnit\Unit\ListingFilter\RangeInterval\Dal;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalCollection;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalEntity;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Dal\FilterBuilderForNonCompatibleFields;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Dal\RequestValue;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\SalesChannel\Listing\Filter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Bucket\FilterAggregation;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Metric\CountAggregation;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+#[CoversClass(FilterBuilderForNonCompatibleFields::class)]
+final class FilterBuilderForNonCompatibleFieldsTest extends TestCase
+{
+    public function testBuildFilterThrowsExceptionWhenIntervalsNotLoaded(): void
+    {
+        $config = new RangeIntervalListingFilterConfigurationEntity();
+        $config->setId(Uuid::randomHex());
+        $config->setUniqueName('test_filter_no_intervals');
+        $config->setDalField('product.width');
+        $config->setPosition(40);
+
+        $requestValue = new RequestValue([]);
+
+        $filterBuilder = new FilterBuilderForNonCompatibleFields();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('`intervals` not loaded in `RangeIntervalListingFilterConfigurationEntity`');
+
+        $filterBuilder->buildFilter($config, $requestValue);
+    }
+
+    public function testBuildFilterWithEmptyIntervalCollectionInConfig(): void
+    {
+        $config = new RangeIntervalListingFilterConfigurationEntity();
+        $config->setId(Uuid::randomHex());
+        $config->setUniqueName('test_filter_empty_config');
+        $config->setDalField('product.height');
+        $config->setPosition(30);
+
+        $intervalCollection = new RangeIntervalListingFilterConfigurationIntervalCollection([]);
+        $config->setIntervals($intervalCollection);
+
+        $requestValue = new RequestValue([]);
+
+        $filterBuilder = new FilterBuilderForNonCompatibleFields();
+        $filter = $filterBuilder->buildFilter($config, $requestValue);
+
+        $this->assertInstanceOf(Filter::class, $filter);
+        $this->assertSame($config->getFilterName(), $filter->getName());
+        $this->assertFalse($filter->isFiltered());
+        $this->assertEmpty($filter->getValues());
+
+        $mainFilter = $filter->getFilter();
+        $this->assertInstanceOf(RangeFilter::class, $mainFilter);
+        $this->assertSame($config->getFullyQualifiedDalField(), $mainFilter->getField());
+        $this->assertEmpty($mainFilter->getParameters());
+
+        $aggregations = $filter->getAggregations();
+        $this->assertCount(0, $aggregations);
+    }
+
+    public function testBuildFilterWithIntervalsAndRequestValue(): void
+    {
+        $config = new RangeIntervalListingFilterConfigurationEntity();
+        $configId = Uuid::randomHex();
+        $config->setId($configId);
+        $config->setUniqueName('test_filter');
+        $config->setDalField('product.price');
+        $config->setPosition(10);
+
+        $interval1 = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval1->setId(Uuid::randomHex());
+        $interval1->setMin(0);
+        $interval1->setMax(100);
+        $interval1->setPosition(1);
+        $interval1->setRangeIntervalListingFilterConfigurationId($configId);
+        $interval1->setRangeIntervalListingFilterConfiguration($config);
+
+        $interval2 = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval2->setId(Uuid::randomHex());
+        $interval2->setMin(100);
+        $interval2->setMax(200);
+        $interval2->setPosition(2);
+        $interval2->setRangeIntervalListingFilterConfigurationId($configId);
+        $interval2->setRangeIntervalListingFilterConfiguration($config);
+
+        $intervalCollection = new RangeIntervalListingFilterConfigurationIntervalCollection([$interval1, $interval2]);
+        $config->setIntervals($intervalCollection);
+
+        $requestValue = new RequestValue([$interval1]);
+        $expectedRequestRange = [
+            RangeFilter::GTE => 0,
+            RangeFilter::LTE => 100,
+        ];
+
+        $filterBuilder = new FilterBuilderForNonCompatibleFields();
+        $filter = $filterBuilder->buildFilter($config, $requestValue);
+
+        $this->assertInstanceOf(Filter::class, $filter);
+        $this->assertSame($config->getFilterName(), $filter->getName());
+        $this->assertTrue($filter->isFiltered());
+        $this->assertSame($expectedRequestRange, $filter->getValues());
+
+        $mainFilter = $filter->getFilter();
+        $this->assertInstanceOf(RangeFilter::class, $mainFilter);
+        $this->assertSame($config->getFullyQualifiedDalField(), $mainFilter->getField());
+        $this->assertSame($expectedRequestRange, $mainFilter->getParameters());
+
+        $aggregations = $filter->getAggregations();
+        $this->assertCount(2, $aggregations);
+
+        $agg1 = $aggregations[0];
+        $this->assertInstanceOf(FilterAggregation::class, $agg1);
+        $this->assertSame($interval1->getCountAggregationName(), $agg1->getName());
+
+        $innerAgg1 = $agg1->getAggregation();
+        $this->assertInstanceOf(CountAggregation::class, $innerAgg1);
+        $this->assertSame($interval1->getCountAggregationName(), $innerAgg1->getName());
+        $this->assertSame($config->getFullyQualifiedDalField(), $innerAgg1->getField());
+
+        $aggFilter1 = $agg1->getFilter();
+        $this->assertCount(1, $aggFilter1);
+        $this->assertInstanceOf(RangeFilter::class, $aggFilter1[0]);
+        $this->assertSame($config->getFullyQualifiedDalField(), $aggFilter1[0]->getField());
+        $this->assertSame($interval1->getRangeForFilter(), $aggFilter1[0]->getParameters());
+
+        $agg2 = $aggregations[1];
+        $this->assertInstanceOf(FilterAggregation::class, $agg2);
+        $this->assertSame($interval2->getCountAggregationName(), $agg2->getName());
+
+        $innerAgg2 = $agg2->getAggregation();
+        $this->assertInstanceOf(CountAggregation::class, $innerAgg2);
+        $this->assertSame($interval2->getCountAggregationName(), $innerAgg2->getName());
+        $this->assertSame($config->getFullyQualifiedDalField(), $innerAgg2->getField());
+
+        $aggFilter2 = $agg2->getFilter();
+        $this->assertCount(1, $aggFilter2);
+        $this->assertInstanceOf(RangeFilter::class, $aggFilter2[0]);
+        $this->assertSame($config->getFullyQualifiedDalField(), $aggFilter2[0]->getField());
+        $this->assertSame($interval2->getRangeForFilter(), $aggFilter2[0]->getParameters());
+    }
+
+    public function testBuildFilterWithNoSelectedIntervals(): void
+    {
+        $config = new RangeIntervalListingFilterConfigurationEntity();
+        $configId = Uuid::randomHex();
+        $config->setId($configId);
+        $config->setUniqueName('test_filter_no_selection');
+        $config->setDalField('product.stock');
+        $config->setPosition(20);
+
+        $interval1 = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval1Id = Uuid::randomHex();
+        $interval1->setId($interval1Id);
+        $interval1->setMin(0);
+        $interval1->setMax(10);
+        $interval1->setPosition(1);
+        $interval1->setRangeIntervalListingFilterConfigurationId($configId);
+        $interval1->setRangeIntervalListingFilterConfiguration($config);
+
+        $intervalCollection = new RangeIntervalListingFilterConfigurationIntervalCollection([$interval1]);
+        $config->setIntervals($intervalCollection);
+
+        $requestValue = new RequestValue([]);
+        $expectedRequestRange = [];
+
+        $filterBuilder = new FilterBuilderForNonCompatibleFields();
+        $filter = $filterBuilder->buildFilter($config, $requestValue);
+
+        $this->assertInstanceOf(Filter::class, $filter);
+        $this->assertSame($config->getFilterName(), $filter->getName());
+        $this->assertFalse($filter->isFiltered());
+        $this->assertSame($expectedRequestRange, $filter->getValues());
+
+        $mainFilter = $filter->getFilter();
+        $this->assertInstanceOf(RangeFilter::class, $mainFilter);
+        $this->assertSame($config->getFullyQualifiedDalField(), $mainFilter->getField());
+        $this->assertSame($expectedRequestRange, $mainFilter->getParameters());
+
+        $aggregations = $filter->getAggregations();
+        $this->assertCount(1, $aggregations);
+
+        $agg1 = $aggregations[0];
+        $this->assertInstanceOf(FilterAggregation::class, $agg1);
+        $this->assertSame($interval1->getCountAggregationName(), $agg1->getName());
+    }
+}

--- a/tests/PHPUnit/Unit/ListingFilter/RangeInterval/Dal/FilterBuilderTest.php
+++ b/tests/PHPUnit/Unit/ListingFilter/RangeInterval/Dal/FilterBuilderTest.php
@@ -1,0 +1,481 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\Test\PHPUnit\Unit\ListingFilter\RangeInterval\Dal;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalCollection;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalEntity;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Dal\FilterBuilder;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Dal\FilterBuilderInterface;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Dal\RequestValue;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\RangeAggregationCompatibilityCheckerInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\SalesChannel\Listing\Filter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Bucket\FilterAggregation;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Metric\RangeAggregation;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+#[CoversClass(FilterBuilder::class)]
+final class FilterBuilderTest extends TestCase
+{
+    private FilterBuilder $filterBuilder;
+
+    private MockObject&FilterBuilderInterface $filterBuilderForNonCompatibleFieldsMock;
+
+    private MockObject&RangeAggregationCompatibilityCheckerInterface $rangeAggregationCompatibilityCheckerMock;
+
+    protected function setUp(): void
+    {
+        $this->rangeAggregationCompatibilityCheckerMock = $this->createMock(RangeAggregationCompatibilityCheckerInterface::class);
+        $this->filterBuilderForNonCompatibleFieldsMock = $this->createMock(FilterBuilderInterface::class);
+        $this->filterBuilder = new FilterBuilder(
+            $this->rangeAggregationCompatibilityCheckerMock,
+            $this->filterBuilderForNonCompatibleFieldsMock
+        );
+    }
+
+    public static function buildFilterWithCompatibleFieldFilteredClosedRangeProvider(): \Generator
+    {
+        $config = new RangeIntervalListingFilterConfigurationEntity();
+        $config->setId(Uuid::randomHex());
+        $config->setUniqueName(Uuid::randomHex());
+        $config->setDalField('price.gross');
+        $config->setPosition(10);
+
+        $interval1 = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval1->setId(Uuid::randomHex());
+        $interval1->setMin(0);
+        $interval1->setMax(100);
+        $interval1->setPosition(10);
+
+        $interval2 = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval2->setId(Uuid::randomHex());
+        $interval2->setMin(101);
+        $interval2->setMax(500);
+        $interval2->setPosition(20);
+
+        $interval3 = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval3->setId(Uuid::randomHex());
+        $interval3->setMin(501);
+        $interval3->setMax(null);
+        $interval3->setPosition(30);
+
+        $intervals = new RangeIntervalListingFilterConfigurationIntervalCollection([$interval1, $interval2, $interval3]);
+        $config->setIntervals($intervals);
+
+        $requestValueSingle = new RequestValue([$interval2]);
+        yield 'compatible field, single selection' => [
+            $config,
+            $requestValueSingle,
+            [
+                RangeFilter::GTE => 101.0,
+                RangeFilter::LTE => 500.0,
+            ],
+            [
+                [
+                    'from' => null,
+                    'to' => 100.0,
+                    'key' => $interval1->getId(),
+                ],
+                [
+                    'from' => 101.0,
+                    'to' => 500.0,
+                    'key' => $interval2->getId(),
+                ],
+                [
+                    'from' => 501.0,
+                    'to' => null,
+                    'key' => $interval3->getId(),
+                ],
+            ],
+        ];
+
+        $requestValueMultipleClosed = new RequestValue([$interval1, $interval2]);
+        yield 'compatible field, multiple selection closed end' => [
+            $config,
+            $requestValueMultipleClosed,
+            [
+                RangeFilter::GTE => 0.0,
+                RangeFilter::LTE => 500.0,
+            ],
+            [
+                [
+                    'from' => null,
+                    'to' => 100.0,
+                    'key' => $interval1->getId(),
+                ],
+                [
+                    'from' => 101.0,
+                    'to' => 500.0,
+                    'key' => $interval2->getId(),
+                ],
+                [
+                    'from' => 501.0,
+                    'to' => null,
+                    'key' => $interval3->getId(),
+                ],
+            ],
+        ];
+    }
+
+    public static function buildFilterWithCompatibleFieldFilteredOpenEndedRangeProvider(): \Generator
+    {
+        $config = new RangeIntervalListingFilterConfigurationEntity();
+        $config->setId(Uuid::randomHex());
+        $config->setUniqueName(Uuid::randomHex());
+        $config->setDalField('price.gross');
+        $config->setPosition(10);
+
+        $interval1 = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval1->setId(Uuid::randomHex());
+        $interval1->setMin(0);
+        $interval1->setMax(100);
+        $interval1->setPosition(10);
+
+        $interval2 = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval2->setId(Uuid::randomHex());
+        $interval2->setMin(101);
+        $interval2->setMax(500);
+        $interval2->setPosition(20);
+
+        $interval3 = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval3->setId(Uuid::randomHex());
+        $interval3->setMin(501);
+        $interval3->setMax(null);
+        $interval3->setPosition(30);
+
+        $intervals = new RangeIntervalListingFilterConfigurationIntervalCollection([$interval1, $interval2, $interval3]);
+        $config->setIntervals($intervals);
+
+        $requestValueMultiple = new RequestValue([$interval1, $interval3]);
+        yield 'compatible field, multiple selection including open end' => [
+            $config,
+            $requestValueMultiple,
+            [
+                RangeFilter::GTE => 0.0,
+            ],
+            [
+                RangeFilter::GTE => 0.0,
+            ],
+            [
+                [
+                    'from' => null,
+                    'to' => 100.0,
+                    'key' => $interval1->getId(),
+                ],
+                [
+                    'from' => 101.0,
+                    'to' => 500.0,
+                    'key' => $interval2->getId(),
+                ],
+                [
+                    'from' => 501.0,
+                    'to' => null,
+                    'key' => $interval3->getId(),
+                ],
+            ],
+        ];
+    }
+
+    public static function buildFilterWithCompatibleFieldNotFilteredProvider(): \Generator
+    {
+        $config = new RangeIntervalListingFilterConfigurationEntity();
+        $config->setId(Uuid::randomHex());
+        $config->setUniqueName(Uuid::randomHex());
+        $config->setDalField('price.gross');
+        $config->setPosition(10);
+
+        $interval1 = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval1->setId(Uuid::randomHex());
+        $interval1->setMin(0);
+        $interval1->setMax(100);
+        $interval1->setPosition(10);
+
+        $interval2 = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval2->setId(Uuid::randomHex());
+        $interval2->setMin(101);
+        $interval2->setMax(500);
+        $interval2->setPosition(20);
+
+        $interval3 = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval3->setId(Uuid::randomHex());
+        $interval3->setMin(501);
+        $interval3->setMax(null);
+        $interval3->setPosition(30);
+
+        $intervals = new RangeIntervalListingFilterConfigurationIntervalCollection([$interval1, $interval2, $interval3]);
+        $config->setIntervals($intervals);
+
+        $requestValueEmpty = new RequestValue([]);
+        yield 'compatible field, no selection' => [
+            $config,
+            $requestValueEmpty,
+            [],
+            [
+                [
+                    'from' => null,
+                    'to' => 100.0,
+                    'key' => $interval1->getId(),
+                ],
+                [
+                    'from' => 101.0,
+                    'to' => 500.0,
+                    'key' => $interval2->getId(),
+                ],
+                [
+                    'from' => 501.0,
+                    'to' => null,
+                    'key' => $interval3->getId(),
+                ],
+            ],
+        ];
+    }
+
+    public function testBuildFilterThrowsExceptionWhenIntervalsNotLoaded(): void
+    {
+        $config = new RangeIntervalListingFilterConfigurationEntity();
+        $config->setId(Uuid::randomHex());
+        $config->setUniqueName(Uuid::randomHex());
+        $config->setDalField('price.gross');
+        $config->setPosition(20);
+
+        $requestValue = new RequestValue([]);
+
+        $this->rangeAggregationCompatibilityCheckerMock
+            ->expects($this->once())
+            ->method('isDalFieldRangeAggregationCompatible')
+            ->with($config->getDalField())
+            ->willReturn(true);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('`intervals` not loaded in `RangeIntervalListingFilterConfigurationEntity`');
+
+        $this->filterBuilder->buildFilter($config, $requestValue);
+    }
+
+    /**
+     * @param array<string, mixed> $expectedFilterValues
+     * @param array<array<string, mixed>> $expectedAggregationRanges
+     */
+    #[DataProvider('buildFilterWithCompatibleFieldFilteredClosedRangeProvider')]
+    public function testBuildFilterWithCompatibleFieldFilteredClosedRange(
+        RangeIntervalListingFilterConfigurationEntity $configurationEntity,
+        RequestValue $requestValue,
+        array $expectedFilterValues,
+        array $expectedAggregationRanges
+    ): void {
+        $this->rangeAggregationCompatibilityCheckerMock
+            ->expects($this->once())
+            ->method('isDalFieldRangeAggregationCompatible')
+            ->with($configurationEntity->getDalField())
+            ->willReturn(true);
+
+        $this->filterBuilderForNonCompatibleFieldsMock
+            ->expects($this->never())
+            ->method('buildFilter');
+
+        $filter = $this->filterBuilder->buildFilter($configurationEntity, $requestValue);
+
+        $this->assertInstanceOf(Filter::class, $filter);
+        $this->assertSame($configurationEntity->getFilterName(), $filter->getName());
+        $this->assertTrue($filter->isFiltered());
+        $this->assertEquals($expectedFilterValues, $filter->getValues());
+
+        $aggregations = $filter->getAggregations();
+        $this->assertCount(1, $aggregations);
+        $filteredAggregation = array_values($aggregations)[0];
+        $this->assertInstanceOf(FilterAggregation::class, $filteredAggregation);
+        $this->assertSame($configurationEntity->getAggregationName(), $filteredAggregation->getName());
+
+        $innerAggregation = $filteredAggregation->getAggregation();
+        $this->assertInstanceOf(RangeAggregation::class, $innerAggregation);
+        $this->assertSame($configurationEntity->getAggregationName(), $innerAggregation->getName());
+        $this->assertSame($configurationEntity->getFullyQualifiedDalField(), $innerAggregation->getField());
+        $this->assertEquals($expectedAggregationRanges, $innerAggregation->getRanges());
+
+        $aggregationFilters = $filteredAggregation->getFilter();
+        $this->assertCount(1, $aggregationFilters);
+        $notNullFilter = array_values($aggregationFilters)[0];
+        $this->assertInstanceOf(NotFilter::class, $notNullFilter);
+        $this->assertSame(MultiFilter::CONNECTION_AND, $notNullFilter->getOperator());
+        $this->assertCount(1, $notNullFilter->getQueries());
+        $equalsNullFilter = $notNullFilter->getQueries()[0];
+        $this->assertInstanceOf(EqualsFilter::class, $equalsNullFilter);
+        $this->assertSame($configurationEntity->getFullyQualifiedDalField(), $equalsNullFilter->getField());
+        $this->assertNull($equalsNullFilter->getValue());
+
+        $mainFilter = $filter->getFilter();
+        $this->assertInstanceOf(RangeFilter::class, $mainFilter);
+        $this->assertSame($configurationEntity->getFullyQualifiedDalField(), $mainFilter->getField());
+        $this->assertEquals($expectedFilterValues, $mainFilter->getParameters());
+    }
+
+    /**
+     * @param array<string, mixed> $expectedFilterValues
+     * @param array<string, mixed> $expectedMainFilterParams
+     * @param array<array<string, mixed>> $expectedAggregationRanges
+     */
+    #[DataProvider('buildFilterWithCompatibleFieldFilteredOpenEndedRangeProvider')]
+    public function testBuildFilterWithCompatibleFieldFilteredOpenEndedRange(
+        RangeIntervalListingFilterConfigurationEntity $configurationEntity,
+        RequestValue $requestValue,
+        array $expectedFilterValues,
+        array $expectedMainFilterParams,
+        array $expectedAggregationRanges
+    ): void {
+        $this->rangeAggregationCompatibilityCheckerMock
+            ->expects($this->once())
+            ->method('isDalFieldRangeAggregationCompatible')
+            ->with($configurationEntity->getDalField())
+            ->willReturn(true);
+
+        $this->filterBuilderForNonCompatibleFieldsMock
+            ->expects($this->never())
+            ->method('buildFilter');
+
+        $filter = $this->filterBuilder->buildFilter($configurationEntity, $requestValue);
+
+        $this->assertInstanceOf(Filter::class, $filter);
+        $this->assertSame($configurationEntity->getFilterName(), $filter->getName());
+        $this->assertTrue($filter->isFiltered());
+        $this->assertEquals($expectedFilterValues, $filter->getValues());
+
+        $aggregations = $filter->getAggregations();
+        $this->assertCount(1, $aggregations);
+        $filteredAggregation = array_values($aggregations)[0];
+        $this->assertInstanceOf(FilterAggregation::class, $filteredAggregation);
+        $this->assertSame($configurationEntity->getAggregationName(), $filteredAggregation->getName());
+
+        $innerAggregation = $filteredAggregation->getAggregation();
+        $this->assertInstanceOf(RangeAggregation::class, $innerAggregation);
+        $this->assertSame($configurationEntity->getAggregationName(), $innerAggregation->getName());
+        $this->assertSame($configurationEntity->getFullyQualifiedDalField(), $innerAggregation->getField());
+        $this->assertEquals($expectedAggregationRanges, $innerAggregation->getRanges());
+
+        $aggregationFilters = $filteredAggregation->getFilter();
+        $this->assertCount(1, $aggregationFilters);
+        $notNullFilter = array_values($aggregationFilters)[0];
+        $this->assertInstanceOf(NotFilter::class, $notNullFilter);
+        $this->assertSame(MultiFilter::CONNECTION_AND, $notNullFilter->getOperator());
+        $this->assertCount(1, $notNullFilter->getQueries());
+        $equalsNullFilter = $notNullFilter->getQueries()[0];
+        $this->assertInstanceOf(EqualsFilter::class, $equalsNullFilter);
+        $this->assertSame($configurationEntity->getFullyQualifiedDalField(), $equalsNullFilter->getField());
+        $this->assertNull($equalsNullFilter->getValue());
+
+        $mainFilter = $filter->getFilter();
+        $this->assertInstanceOf(RangeFilter::class, $mainFilter);
+        $this->assertSame($configurationEntity->getFullyQualifiedDalField(), $mainFilter->getField());
+        $this->assertEquals($expectedMainFilterParams, $mainFilter->getParameters());
+    }
+
+    /**
+     * @param array<string, mixed> $expectedFilterValues
+     * @param array<array<string, mixed>> $expectedAggregationRanges
+     */
+    #[DataProvider('buildFilterWithCompatibleFieldNotFilteredProvider')]
+    public function testBuildFilterWithCompatibleFieldNotFiltered(
+        RangeIntervalListingFilterConfigurationEntity $configurationEntity,
+        RequestValue $requestValue,
+        array $expectedFilterValues,
+        array $expectedAggregationRanges
+    ): void {
+        $this->rangeAggregationCompatibilityCheckerMock
+            ->expects($this->once())
+            ->method('isDalFieldRangeAggregationCompatible')
+            ->with($configurationEntity->getDalField())
+            ->willReturn(true);
+
+        $this->filterBuilderForNonCompatibleFieldsMock
+            ->expects($this->never())
+            ->method('buildFilter');
+
+        $filter = $this->filterBuilder->buildFilter($configurationEntity, $requestValue);
+
+        $this->assertInstanceOf(Filter::class, $filter);
+        $this->assertSame($configurationEntity->getFilterName(), $filter->getName());
+        $this->assertFalse($filter->isFiltered());
+        $this->assertEquals($expectedFilterValues, $filter->getValues());
+
+        $aggregations = $filter->getAggregations();
+        $this->assertCount(1, $aggregations);
+        $filteredAggregation = array_values($aggregations)[0];
+        $this->assertInstanceOf(FilterAggregation::class, $filteredAggregation);
+        $this->assertSame($configurationEntity->getAggregationName(), $filteredAggregation->getName());
+
+        $innerAggregation = $filteredAggregation->getAggregation();
+        $this->assertInstanceOf(RangeAggregation::class, $innerAggregation);
+        $this->assertSame($configurationEntity->getAggregationName(), $innerAggregation->getName());
+        $this->assertSame($configurationEntity->getFullyQualifiedDalField(), $innerAggregation->getField());
+        $this->assertEquals($expectedAggregationRanges, $innerAggregation->getRanges());
+
+        $aggregationFilters = $filteredAggregation->getFilter();
+        $this->assertCount(1, $aggregationFilters);
+        $notNullFilter = array_values($aggregationFilters)[0];
+        $this->assertInstanceOf(NotFilter::class, $notNullFilter);
+        $this->assertSame(MultiFilter::CONNECTION_AND, $notNullFilter->getOperator());
+        $this->assertCount(1, $notNullFilter->getQueries());
+        $equalsNullFilter = $notNullFilter->getQueries()[0];
+        $this->assertInstanceOf(EqualsFilter::class, $equalsNullFilter);
+        $this->assertSame($configurationEntity->getFullyQualifiedDalField(), $equalsNullFilter->getField());
+        $this->assertNull($equalsNullFilter->getValue());
+
+        $mainFilter = $filter->getFilter();
+        $this->assertInstanceOf(RangeFilter::class, $mainFilter);
+        $this->assertSame($configurationEntity->getFullyQualifiedDalField(), $mainFilter->getField());
+        $this->assertEmpty($mainFilter->getParameters());
+    }
+
+    public function testBuildFilterWithNonCompatibleFieldCallsFallback(): void
+    {
+        $config = new RangeIntervalListingFilterConfigurationEntity();
+        $config->setId(Uuid::randomHex());
+        $config->setUniqueName(Uuid::randomHex());
+        $config->setDalField('some.non.compatible.field');
+        $config->setPosition(30);
+
+        $interval = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval->setId(Uuid::randomHex());
+        $interval->setMin(0);
+        $interval->setMax(100);
+        $interval->setPosition(10);
+
+        $config->setIntervals(new RangeIntervalListingFilterConfigurationIntervalCollection([$interval]));
+
+        $requestValue = new RequestValue([]);
+
+        $this->rangeAggregationCompatibilityCheckerMock
+            ->expects($this->once())
+            ->method('isDalFieldRangeAggregationCompatible')
+            ->with($config->getDalField())
+            ->willReturn(false);
+
+        $expectedFilterMock = $this->createMock(Filter::class);
+        $this->filterBuilderForNonCompatibleFieldsMock
+            ->expects($this->once())
+            ->method('buildFilter')
+            ->with($this->identicalTo($config), $this->identicalTo($requestValue))
+            ->willReturnCallback(function (
+                RangeIntervalListingFilterConfigurationEntity $passedConfig,
+                RequestValue $passedRequestValue
+            ) use ($expectedFilterMock, $config, $requestValue): Filter {
+                $this->assertSame($config, $passedConfig);
+                $this->assertSame($requestValue, $passedRequestValue);
+
+                return $expectedFilterMock;
+            });
+
+        $actualFilter = $this->filterBuilder->buildFilter($config, $requestValue);
+
+        $this->assertSame($expectedFilterMock, $actualFilter);
+    }
+}

--- a/tests/PHPUnit/Unit/ListingFilter/RangeInterval/Dal/RequestValueBuilderTest.php
+++ b/tests/PHPUnit/Unit/ListingFilter/RangeInterval/Dal/RequestValueBuilderTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\Test\PHPUnit\Unit\ListingFilter\RangeInterval\Dal;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalCollection;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalEntity;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
+use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelectValueSplitterInterface;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Dal\RequestValue;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Dal\RequestValueBuilder;
+use ITB\ITBConfigurableListingFilters\ListingFilter\ValueFromRequestExtractorInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\Request;
+
+#[CoversClass(RequestValueBuilder::class)]
+final class RequestValueBuilderTest extends TestCase
+{
+    private MockObject&MultiSelectValueSplitterInterface $multiSelectValueSplitterMock;
+
+    private RequestValueBuilder $requestValueBuilder;
+
+    private MockObject&ValueFromRequestExtractorInterface $valueFromRequestExtractorMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->valueFromRequestExtractorMock = $this->createMock(ValueFromRequestExtractorInterface::class);
+        $this->multiSelectValueSplitterMock = $this->createMock(MultiSelectValueSplitterInterface::class);
+        $this->requestValueBuilder = new RequestValueBuilder($this->valueFromRequestExtractorMock, $this->multiSelectValueSplitterMock);
+    }
+
+    public function testBuildRequestValueHappyPath(): void
+    {
+        $config = new RangeIntervalListingFilterConfigurationEntity();
+        $config->setId(Uuid::randomHex());
+        $config->setUniqueName('test_filter');
+        $config->setDalField('product.price');
+
+        $filterName = $config->getFilterName();
+
+        $interval1Id = Uuid::randomHex();
+        $interval1 = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval1->setId($interval1Id);
+        $interval1->setMin(0);
+        $interval1->setMax(100);
+
+        $interval2Id = Uuid::randomHex();
+        $interval2 = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval2->setId($interval2Id);
+        $interval2->setMin(100);
+        $interval2->setMax(200);
+
+        $intervalCollection = new RangeIntervalListingFilterConfigurationIntervalCollection([$interval1, $interval2]);
+        $config->setIntervals($intervalCollection);
+
+        $request = new Request();
+        $requestIdsString = $interval1Id . '|' . $interval2Id;
+        $requestIdsArray = [$interval1Id, $interval2Id];
+
+        $this->valueFromRequestExtractorMock
+            ->expects($this->once())
+            ->method('extractValueFromRequest')
+            ->with($this->identicalTo($request), $filterName)
+            ->willReturn($requestIdsString);
+
+        $this->multiSelectValueSplitterMock
+            ->expects($this->once())
+            ->method('splitMultiSelectValue')
+            ->with($requestIdsString, $this->identicalTo($config))
+            ->willReturn($requestIdsArray);
+
+        $result = $this->requestValueBuilder->buildRequestValue($config, $request);
+
+        $this->assertInstanceOf(RequestValue::class, $result);
+        $this->assertTrue($result->isFiltered());
+        $expectedRange = [
+            'gte' => 0,
+            'lte' => 200,
+        ];
+        $this->assertSame($expectedRange, $result->range());
+    }
+
+    public function testBuildRequestValueIdsNotInCollection(): void
+    {
+        $config = new RangeIntervalListingFilterConfigurationEntity();
+        $config->setId(Uuid::randomHex());
+        $config->setUniqueName('test_filter_wrong_ids');
+        $config->setDalField('product.rating');
+
+        $filterName = $config->getFilterName();
+
+        $interval1 = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval1->setId(Uuid::randomHex());
+
+        $intervalCollection = new RangeIntervalListingFilterConfigurationIntervalCollection([$interval1]);
+        $config->setIntervals($intervalCollection);
+
+        $request = new Request();
+        $nonExistentId = Uuid::randomHex();
+        $requestIdsString = $nonExistentId;
+        $requestIdsArray = [$nonExistentId];
+
+        $this->valueFromRequestExtractorMock
+            ->expects($this->once())
+            ->method('extractValueFromRequest')
+            ->with($this->identicalTo($request), $filterName)
+            ->willReturn($requestIdsString);
+
+        $this->multiSelectValueSplitterMock
+            ->expects($this->once())
+            ->method('splitMultiSelectValue')
+            ->with($requestIdsString, $this->identicalTo($config))
+            ->willReturn($requestIdsArray);
+
+        $result = $this->requestValueBuilder->buildRequestValue($config, $request);
+
+        $this->assertInstanceOf(RequestValue::class, $result);
+        $this->assertFalse($result->isFiltered());
+        $this->assertEmpty($result->range());
+    }
+
+    public function testBuildRequestValueNoIdsInRequest(): void
+    {
+        $config = new RangeIntervalListingFilterConfigurationEntity();
+        $config->setId(Uuid::randomHex());
+        $config->setUniqueName('test_filter_no_ids');
+        $config->setDalField('product.stock');
+
+        $filterName = $config->getFilterName();
+
+        $interval1 = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval1->setId(Uuid::randomHex());
+
+        $intervalCollection = new RangeIntervalListingFilterConfigurationIntervalCollection([$interval1]);
+        $config->setIntervals($intervalCollection);
+
+        $request = new Request();
+        $requestIdsString = '';
+        $requestIdsArray = [];
+
+        $this->valueFromRequestExtractorMock
+            ->expects($this->once())
+            ->method('extractValueFromRequest')
+            ->with($this->identicalTo($request), $filterName)
+            ->willReturn($requestIdsString);
+
+        $this->multiSelectValueSplitterMock
+            ->expects($this->once())
+            ->method('splitMultiSelectValue')
+            ->with($requestIdsString, $this->identicalTo($config))
+            ->willReturn($requestIdsArray);
+
+        $result = $this->requestValueBuilder->buildRequestValue($config, $request);
+
+        $this->assertInstanceOf(RequestValue::class, $result);
+        $this->assertFalse($result->isFiltered());
+        $this->assertEmpty($result->range());
+    }
+
+    public function testBuildRequestValueThrowsExceptionWhenIntervalsNotLoaded(): void
+    {
+        $config = new RangeIntervalListingFilterConfigurationEntity();
+        $config->setId(Uuid::randomHex());
+        $config->setUniqueName('test_filter_no_intervals_loaded');
+        $config->setDalField('product.someField');
+
+        $filterName = $config->getFilterName();
+
+        $request = new Request();
+        $requestIdsString = Uuid::randomHex();
+        $requestIdsArray = [$requestIdsString];
+
+        $this->valueFromRequestExtractorMock
+            ->expects($this->once())
+            ->method('extractValueFromRequest')
+            ->with($this->identicalTo($request), $filterName)
+            ->willReturn($requestIdsString);
+
+        $this->multiSelectValueSplitterMock
+            ->expects($this->once())
+            ->method('splitMultiSelectValue')
+            ->with($requestIdsString, $this->identicalTo($config))
+            ->willReturn($requestIdsArray);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('`intervals` not loaded in `RangeIntervalListingFilterConfigurationEntity`');
+
+        $this->requestValueBuilder->buildRequestValue($config, $request);
+    }
+}

--- a/tests/PHPUnit/Unit/ListingFilter/RangeInterval/Dal/RequestValueTest.php
+++ b/tests/PHPUnit/Unit/ListingFilter/RangeInterval/Dal/RequestValueTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\Test\PHPUnit\Unit\ListingFilter\RangeInterval\Dal;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalEntity;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Dal\RequestValue;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+#[CoversClass(RequestValue::class)]
+final class RequestValueTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{intervals: array<RangeIntervalListingFilterConfigurationIntervalEntity>, expectedRange: array{gte?: int, lte?: int}}>
+     */
+    public static function rangeDataProvider(): iterable
+    {
+        $interval0_100 = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval0_100->setId(Uuid::randomHex());
+        $interval0_100->setMin(0);
+        $interval0_100->setMax(100);
+
+        $interval50_150 = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval50_150->setId(Uuid::randomHex());
+        $interval50_150->setMin(50);
+        $interval50_150->setMax(150);
+
+        $interval100_200 = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval100_200->setId(Uuid::randomHex());
+        $interval100_200->setMin(100);
+        $interval100_200->setMax(200);
+
+        $intervalNull_50 = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $intervalNull_50->setId(Uuid::randomHex());
+        $intervalNull_50->setMin(null);
+        $intervalNull_50->setMax(50);
+
+        $interval150_Null = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval150_Null->setId(Uuid::randomHex());
+        $interval150_Null->setMin(150);
+        $interval150_Null->setMax(null);
+
+        $intervalNull_Null = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $intervalNull_Null->setId(Uuid::randomHex());
+        $intervalNull_Null->setMin(null);
+        $intervalNull_Null->setMax(null);
+
+        yield 'Empty intervals' => [
+            'intervals' => [],
+            'expectedRange' => [],
+        ];
+
+        yield 'Single closed interval' => [
+            'intervals' => [$interval0_100],
+            'expectedRange' => [
+                RangeFilter::GTE => 0,
+                RangeFilter::LTE => 100,
+            ],
+        ];
+
+        yield 'Two overlapping closed intervals' => [
+            'intervals' => [$interval0_100, $interval50_150],
+            'expectedRange' => [
+                RangeFilter::GTE => 0,
+                RangeFilter::LTE => 150,
+            ],
+        ];
+
+        yield 'Two non-overlapping closed intervals' => [
+            'intervals' => [$interval0_100, $interval100_200],
+            'expectedRange' => [
+                RangeFilter::GTE => 0,
+                RangeFilter::LTE => 200,
+            ],
+        ];
+
+        yield 'Single open lower bound interval' => [
+            'intervals' => [$intervalNull_50],
+            'expectedRange' => [
+                RangeFilter::LTE => 50,
+            ],
+        ];
+
+        yield 'Single open upper bound interval' => [
+            'intervals' => [$interval150_Null],
+            'expectedRange' => [
+                RangeFilter::GTE => 150,
+            ],
+        ];
+
+        yield 'Single open lower and upper bound interval' => [
+            'intervals' => [$intervalNull_Null],
+            'expectedRange' => [],
+        ];
+
+        yield 'Mixed intervals including open lower bound' => [
+            'intervals' => [$interval0_100, $intervalNull_50],
+            'expectedRange' => [
+                RangeFilter::LTE => 100,
+            ],
+        ];
+
+        yield 'Mixed intervals including open upper bound' => [
+            'intervals' => [$interval0_100, $interval150_Null],
+            'expectedRange' => [
+                RangeFilter::GTE => 0,
+            ],
+        ];
+
+        yield 'Mixed intervals including open lower and upper bounds' => [
+            'intervals' => [$interval0_100, $intervalNull_50, $interval150_Null],
+            'expectedRange' => [],
+        ];
+    }
+
+    public function testIsFilteredWithEmptyIntervals(): void
+    {
+        $requestValue = new RequestValue([]);
+        $this->assertFalse($requestValue->isFiltered());
+    }
+
+    public function testIsFilteredWithNonEmptyIntervals(): void
+    {
+        $interval = new RangeIntervalListingFilterConfigurationIntervalEntity();
+        $interval->setId(Uuid::randomHex());
+        $interval->setMin(0);
+        $interval->setMax(100);
+
+        $requestValue = new RequestValue([$interval]);
+        $this->assertTrue($requestValue->isFiltered());
+    }
+
+    /**
+     * @param array<RangeIntervalListingFilterConfigurationIntervalEntity> $intervals
+     * @param array{gte?: int, lte?: int} $expectedRange
+     */
+    #[DataProvider('rangeDataProvider')]
+    public function testRange(array $intervals, array $expectedRange): void
+    {
+        $requestValue = new RequestValue($intervals);
+        $this->assertSame($expectedRange, $requestValue->range());
+    }
+}

--- a/tests/PHPUnit/Unit/ListingFilter/RangeInterval/RangeAggregationCompatibilityCheckerTest.php
+++ b/tests/PHPUnit/Unit/ListingFilter/RangeInterval/RangeAggregationCompatibilityCheckerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\Test\PHPUnit\Unit\ListingFilter\RangeInterval;
+
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\RangeAggregationCompatibilityChecker;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
+use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FloatField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\PriceField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+
+#[CoversClass(RangeAggregationCompatibilityChecker::class)]
+final class RangeAggregationCompatibilityCheckerTest extends TestCase
+{
+    private RangeAggregationCompatibilityChecker $compatibilityChecker;
+
+    private MockObject&EntityDefinition $productDefinitionMock;
+
+    private MockObject&EntityDefinitionQueryHelper $queryHelperMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->queryHelperMock = $this->createMock(EntityDefinitionQueryHelper::class);
+        $definitionRegistryMock = $this->createMock(DefinitionInstanceRegistry::class);
+        $this->productDefinitionMock = $this->createMock(EntityDefinition::class);
+
+        $definitionRegistryMock
+            ->method('getByEntityName')
+            ->with(ProductDefinition::ENTITY_NAME)
+            ->willReturn($this->productDefinitionMock);
+
+        $this->compatibilityChecker = new RangeAggregationCompatibilityChecker($this->queryHelperMock, $definitionRegistryMock);
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: class-string<Field>|null, 2: bool}>
+     */
+    public static function provideFieldTypes(): iterable
+    {
+        yield 'PriceField is compatible' => ['product.price', PriceField::class, true];
+        yield 'FloatField is compatible' => ['product.width', FloatField::class, true];
+        yield 'IntField is compatible' => ['product.stock', IntField::class, true];
+        yield 'StringField is not compatible' => ['product.name', StringField::class, false];
+        yield 'Other Field is not compatible' => ['product.customField', Field::class, false]; // Using base Field class as example
+        yield 'Field not found (null) is not compatible' => ['product.nonExistentField', null, false];
+    }
+
+    /**
+     * @param class-string<Field>|null $fieldTypeClass The class name of the field type to mock, or null if getField should return null.
+     */
+    #[DataProvider('provideFieldTypes')]
+    public function testIsDalFieldRangeAggregationCompatible(string $dalField, ?string $fieldTypeClass, bool $expectedResult): void
+    {
+        $fieldMock = $fieldTypeClass !== null && $fieldTypeClass !== '' && $fieldTypeClass !== '0' ? $this->createMock(
+            $fieldTypeClass
+        ) : null;
+
+        $this->queryHelperMock
+            ->expects($this->once())
+            ->method('getField')
+            ->with($dalField, $this->identicalTo($this->productDefinitionMock), ProductDefinition::ENTITY_NAME)
+            ->willReturn($fieldMock);
+
+        $result = $this->compatibilityChecker->isDalFieldRangeAggregationCompatible($dalField);
+
+        $this->assertSame($expectedResult, $result);
+    }
+}

--- a/tests/PHPUnit/Unit/ListingFilter/RangeInterval/Storefront/ElementBuilderTest.php
+++ b/tests/PHPUnit/Unit/ListingFilter/RangeInterval/Storefront/ElementBuilderTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\Test\PHPUnit\Unit\ListingFilter\RangeInterval\Storefront;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalEntity;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
+use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Storefront\Element;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefront\ElementBuilder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+#[CoversClass(ElementBuilder::class)]
+final class ElementBuilderTest extends TestCase
+{
+    private ElementBuilder $elementBuilder;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->elementBuilder = new ElementBuilder();
+    }
+
+    /**
+     * @return iterable<string, array{
+     *     min: int|null,
+     *     max: int|null,
+     *     prefix: string|null,
+     *     suffix: string|null,
+     *     expectedText: string
+     * }>
+     */
+    public static function elementDataProvider(): iterable
+    {
+        yield 'Min and Max set, no prefix/suffix' => [
+            'min' => 10,
+            'max' => 50,
+            'prefix' => null,
+            'suffix' => null,
+            'expectedText' => '10 - 50',
+        ];
+
+        yield 'Min and Max set, with prefix/suffix' => [
+            'min' => 0,
+            'max' => 100,
+            'prefix' => '€',
+            'suffix' => '!',
+            'expectedText' => '€0! - €100!',
+        ];
+
+        yield 'Min null, Max set, no prefix/suffix' => [
+            'min' => null,
+            'max' => 99,
+            'prefix' => null,
+            'suffix' => null,
+            'expectedText' => '< 99',
+        ];
+
+        yield 'Min null, Max set, with prefix/suffix' => [
+            'min' => null,
+            'max' => 50,
+            'prefix' => '$',
+            'suffix' => ' USD',
+            'expectedText' => '< $50 USD',
+        ];
+
+        yield 'Min set, Max null, no prefix/suffix' => [
+            'min' => 200,
+            'max' => null,
+            'prefix' => null,
+            'suffix' => null,
+            'expectedText' => '> 200',
+        ];
+
+        yield 'Min set, Max null, with prefix/suffix' => [
+            'min' => 150,
+            'max' => null,
+            'prefix' => '£',
+            'suffix' => ' GBP',
+            'expectedText' => '> £150 GBP',
+        ];
+
+        yield 'Min and Max set, empty prefix/suffix' => [
+            'min' => 5,
+            'max' => 15,
+            'prefix' => '',
+            'suffix' => '',
+            'expectedText' => '5 - 15',
+        ];
+    }
+
+    #[DataProvider('elementDataProvider')]
+    public function testBuildElement(?int $min, ?int $max, ?string $prefix, ?string $suffix, string $expectedText): void
+    {
+        $intervalId = Uuid::randomHex();
+
+        $configMock = $this->createMock(RangeIntervalListingFilterConfigurationEntity::class);
+        $configMock->method('getElementPrefix')
+            ->willReturn($prefix);
+        $configMock->method('getElementSuffix')
+            ->willReturn($suffix);
+
+        $intervalMock = $this->createMock(RangeIntervalListingFilterConfigurationIntervalEntity::class);
+        $intervalMock->method('getId')
+            ->willReturn($intervalId);
+        $intervalMock->method('getMin')
+            ->willReturn($min);
+        $intervalMock->method('getMax')
+            ->willReturn($max);
+        $intervalMock->method('getRangeIntervalListingFilterConfiguration')
+            ->willReturn($configMock);
+
+        $element = $this->elementBuilder->buildElement($intervalMock);
+
+        $this->assertInstanceOf(Element::class, $element);
+        $this->assertSame($intervalId, $element->name);
+        $this->assertSame($expectedText, $element->text);
+    }
+
+    public function testBuildElementThrowsExceptionWhenMinAndMaxAreNull(): void
+    {
+        $configMock = $this->createMock(RangeIntervalListingFilterConfigurationEntity::class);
+        $configMock->method('getElementPrefix')
+            ->willReturn(null);
+        $configMock->method('getElementSuffix')
+            ->willReturn(null);
+
+        $intervalMock = $this->createMock(RangeIntervalListingFilterConfigurationIntervalEntity::class);
+        $intervalMock->method('getId')
+            ->willReturn(Uuid::randomHex());
+        $intervalMock->method('getMin')
+            ->willReturn(null);
+        $intervalMock->method('getMax')
+            ->willReturn(null);
+        $intervalMock->method('getRangeIntervalListingFilterConfiguration')
+            ->willReturn($configMock);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Both min and max are null. This should be prevented by the pre-persistence validation.');
+
+        $this->elementBuilder->buildElement($intervalMock);
+    }
+}

--- a/tests/PHPUnit/Unit/ListingFilter/RangeInterval/Storefront/ElementsExtractorForNonCompatibleFieldsTest.php
+++ b/tests/PHPUnit/Unit/ListingFilter/RangeInterval/Storefront/ElementsExtractorForNonCompatibleFieldsTest.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\Test\PHPUnit\Unit\ListingFilter\RangeInterval\Storefront;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalCollection;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalEntity;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
+use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Storefront\Element;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefront\ElementBuilderInterface;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefront\ElementsExtractorForNonCompatibleFields;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResultCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Metric\CountResult;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+#[CoversClass(ElementsExtractorForNonCompatibleFields::class)]
+final class ElementsExtractorForNonCompatibleFieldsTest extends TestCase
+{
+    private MockObject&ElementBuilderInterface $elementBuilderMock;
+
+    private ElementsExtractorForNonCompatibleFields $elementsExtractor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->elementBuilderMock = $this->createMock(ElementBuilderInterface::class);
+        $this->elementsExtractor = new ElementsExtractorForNonCompatibleFields($this->elementBuilderMock);
+    }
+
+    public function testExtractElementsFromAggregations(): void
+    {
+        $configMock = $this->createMock(RangeIntervalListingFilterConfigurationEntity::class);
+        $aggregationResultsMock = $this->createMock(AggregationResultCollection::class);
+
+        $intervalId1 = Uuid::randomHex();
+        $intervalId2 = Uuid::randomHex();
+        $intervalId3 = Uuid::randomHex();
+
+        $aggName1 = 'count_agg_1';
+        $aggName2 = 'count_agg_2';
+        $aggName3 = 'count_agg_3';
+
+        $intervalEntity1 = $this->createMock(RangeIntervalListingFilterConfigurationIntervalEntity::class);
+        $intervalEntity1->method('getId')
+            ->willReturn($intervalId1);
+        $intervalEntity1->method('getUniqueIdentifier')
+            ->willReturn($intervalId1);
+        $intervalEntity1->method('getPosition')
+            ->willReturn(1);
+        $intervalEntity1->method('getCountAggregationName')
+            ->willReturn($aggName1);
+        $intervalEntity1->method('getIdFromCountAggregationName')
+            ->with($aggName1)
+            ->willReturn($intervalId1);
+
+        $intervalEntity2 = $this->createMock(RangeIntervalListingFilterConfigurationIntervalEntity::class);
+        $intervalEntity2->method('getId')
+            ->willReturn($intervalId2);
+        $intervalEntity2->method('getUniqueIdentifier')
+            ->willReturn($intervalId2);
+        $intervalEntity2->method('getPosition')
+            ->willReturn(2);
+        $intervalEntity2->method('getCountAggregationName')
+            ->willReturn($aggName2);
+        $intervalEntity2->method('getIdFromCountAggregationName')
+            ->with($aggName2)
+            ->willReturn($intervalId2);
+
+        $intervalEntity3 = $this->createMock(RangeIntervalListingFilterConfigurationIntervalEntity::class);
+        $intervalEntity3->method('getId')
+            ->willReturn($intervalId3);
+        $intervalEntity3->method('getUniqueIdentifier')
+            ->willReturn($intervalId3);
+        $intervalEntity3->method('getPosition')
+            ->willReturn(3);
+        $intervalEntity3->method('getCountAggregationName')
+            ->willReturn($aggName3);
+        $intervalEntity3->method('getIdFromCountAggregationName')
+            ->with($aggName3)
+            ->willReturn($intervalId3);
+
+        $intervalCollection = new RangeIntervalListingFilterConfigurationIntervalCollection([
+            $intervalEntity3,
+            $intervalEntity2,
+            $intervalEntity1,
+        ]);
+
+        $countResult1 = $this->createMock(CountResult::class);
+        $countResult1->method('getCount')
+            ->willReturn(5);
+        $countResult1->method('getName')
+            ->willReturn($aggName1);
+
+        $countResult2 = $this->createMock(CountResult::class);
+        $countResult2->method('getCount')
+            ->willReturn(10);
+        $countResult2->method('getName')
+            ->willReturn($aggName2);
+
+        $countResult3 = $this->createMock(CountResult::class);
+        $countResult3->method('getCount')
+            ->willReturn(0);
+        $countResult3->method('getName')
+            ->willReturn($aggName3);
+
+        $element1 = new Element($intervalId1, 'Element 1');
+        $element2 = new Element($intervalId2, 'Element 2');
+
+        $configMock->method('getIntervals')
+            ->willReturn($intervalCollection);
+
+        $aggregationResultsMock
+            ->expects($this->exactly(3))
+            ->method('get')
+            ->willReturnMap([[$aggName1, $countResult1], [$aggName2, $countResult2], [$aggName3, $countResult3]]);
+
+        $this->elementBuilderMock
+            ->expects($this->exactly(2))
+            ->method('buildElement')
+            ->willReturnMap([[$intervalEntity1, $element1], [$intervalEntity2, $element2]]);
+
+        $result = $this->elementsExtractor->extractElementsFromAggregations($configMock, $aggregationResultsMock);
+
+        $this->assertCount(2, $result);
+        $this->assertSame([$element1, $element2], $result);
+    }
+
+    public function testExtractElementsFromAggregationsWithNoIntervals(): void
+    {
+        $configMock = $this->createMock(RangeIntervalListingFilterConfigurationEntity::class);
+        $aggregationResultsMock = $this->createMock(AggregationResultCollection::class);
+
+        $configMock->method('getIntervals')
+            ->willReturn(new RangeIntervalListingFilterConfigurationIntervalCollection());
+
+        $aggregationResultsMock->expects($this->never())
+            ->method('get');
+        $this->elementBuilderMock->expects($this->never())
+            ->method('buildElement');
+
+        $result = $this->elementsExtractor->extractElementsFromAggregations($configMock, $aggregationResultsMock);
+
+        $this->assertEmpty($result);
+    }
+
+    public function testExtractElementsThrowsExceptionIfAggregationNotFound(): void
+    {
+        $configMock = $this->createMock(RangeIntervalListingFilterConfigurationEntity::class);
+        $aggregationResultsMock = $this->createMock(AggregationResultCollection::class);
+
+        $intervalId1 = Uuid::randomHex();
+        $aggName1 = 'missing_count_agg';
+
+        $intervalEntity1 = $this->createMock(RangeIntervalListingFilterConfigurationIntervalEntity::class);
+        $intervalEntity1->method('getId')
+            ->willReturn($intervalId1);
+        $intervalEntity1->method('getUniqueIdentifier')
+            ->willReturn($intervalId1);
+        $intervalEntity1->method('getPosition')
+            ->willReturn(1);
+        $intervalEntity1->method('getCountAggregationName')
+            ->willReturn($aggName1);
+
+        $intervalCollection = new RangeIntervalListingFilterConfigurationIntervalCollection([$intervalEntity1]);
+        $configMock->method('getIntervals')
+            ->willReturn($intervalCollection);
+
+        $aggregationResultsMock
+            ->expects($this->once())
+            ->method('get')
+            ->with($aggName1)
+            ->willReturn(null);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(sprintf('The aggregation "%s" could not be found.', $aggName1));
+
+        $this->elementsExtractor->extractElementsFromAggregations($configMock, $aggregationResultsMock);
+    }
+
+    public function testExtractElementsThrowsExceptionIfIntervalsNotLoaded(): void
+    {
+        $configMock = $this->createMock(RangeIntervalListingFilterConfigurationEntity::class);
+        $aggregationResultsMock = $this->createMock(AggregationResultCollection::class);
+
+        $configMock->method('getIntervals')
+            ->willReturn(null);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('`intervals` not loaded in `RangeIntervalListingFilterConfigurationEntity`');
+
+        $this->elementsExtractor->extractElementsFromAggregations($configMock, $aggregationResultsMock);
+    }
+
+    public function testExtractElementsThrowsExceptionIfNotCountResult(): void
+    {
+        $configMock = $this->createMock(RangeIntervalListingFilterConfigurationEntity::class);
+        $aggregationResultsMock = $this->createMock(AggregationResultCollection::class);
+        $wrongAggregationResultMock = $this->createMock(AggregationResult::class);
+
+        $intervalId1 = Uuid::randomHex();
+        $aggName1 = 'wrong_type_agg';
+
+        $intervalEntity1 = $this->createMock(RangeIntervalListingFilterConfigurationIntervalEntity::class);
+        $intervalEntity1->method('getId')
+            ->willReturn($intervalId1);
+        $intervalEntity1->method('getUniqueIdentifier')
+            ->willReturn($intervalId1);
+        $intervalEntity1->method('getPosition')
+            ->willReturn(1);
+        $intervalEntity1->method('getCountAggregationName')
+            ->willReturn($aggName1);
+
+        $intervalCollection = new RangeIntervalListingFilterConfigurationIntervalCollection([$intervalEntity1]);
+        $configMock->method('getIntervals')
+            ->willReturn($intervalCollection);
+
+        $aggregationResultsMock
+            ->expects($this->once())
+            ->method('get')
+            ->with($aggName1)
+            ->willReturn($wrongAggregationResultMock);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(sprintf('The aggregation result "%s" is not a count result.', $aggName1));
+
+        $this->elementsExtractor->extractElementsFromAggregations($configMock, $aggregationResultsMock);
+    }
+}

--- a/tests/PHPUnit/Unit/ListingFilter/RangeInterval/Storefront/ElementsExtractorTest.php
+++ b/tests/PHPUnit/Unit/ListingFilter/RangeInterval/Storefront/ElementsExtractorTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\Test\PHPUnit\Unit\ListingFilter\RangeInterval\Storefront;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalCollection;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\Aggregate\RangeIntervalListingFilterConfigurationIntervalEntity;
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
+use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Storefront\Element;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\RangeAggregationCompatibilityCheckerInterface;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefront\ElementBuilderInterface;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefront\ElementsExtractor;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefront\ElementsExtractorInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResultCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Metric\RangeResult;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+#[CoversClass(ElementsExtractor::class)]
+final class ElementsExtractorTest extends TestCase
+{
+    private MockObject&ElementBuilderInterface $elementBuilderMock;
+
+    private ElementsExtractor $elementsExtractor;
+
+    private MockObject&ElementsExtractorInterface $elementsExtractorForNonCompatibleFieldsMock;
+
+    private MockObject&RangeAggregationCompatibilityCheckerInterface $rangeAggregationCompatibilityCheckerMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->rangeAggregationCompatibilityCheckerMock = $this->createMock(RangeAggregationCompatibilityCheckerInterface::class);
+        $this->elementsExtractorForNonCompatibleFieldsMock = $this->createMock(ElementsExtractorInterface::class);
+        $this->elementBuilderMock = $this->createMock(ElementBuilderInterface::class);
+
+        $this->elementsExtractor = new ElementsExtractor(
+            $this->rangeAggregationCompatibilityCheckerMock,
+            $this->elementsExtractorForNonCompatibleFieldsMock,
+            $this->elementBuilderMock
+        );
+    }
+
+    public function testExtractElementsFromAggregationsForCompatibleField(): void
+    {
+        $configMock = $this->createMock(RangeIntervalListingFilterConfigurationEntity::class);
+        $aggregationResultsMock = $this->createMock(AggregationResultCollection::class);
+        $rangeResultMock = $this->createMock(RangeResult::class);
+        $intervalCollectionMock = $this->createMock(RangeIntervalListingFilterConfigurationIntervalCollection::class);
+
+        $dalField = 'product.price';
+        $aggregationName = 'price_range_agg';
+        $intervalId1 = Uuid::randomHex();
+        $intervalId2 = Uuid::randomHex();
+        $intervalIdNotFound = Uuid::randomHex();
+
+        $intervalEntity1 = $this->createMock(RangeIntervalListingFilterConfigurationIntervalEntity::class);
+        $intervalEntity1->method('getId')
+            ->willReturn($intervalId1);
+        $intervalEntity1->method('getUniqueIdentifier')
+            ->willReturn($intervalId1);
+
+        $intervalEntity2 = $this->createMock(RangeIntervalListingFilterConfigurationIntervalEntity::class);
+        $intervalEntity2->method('getId')
+            ->willReturn($intervalId2);
+        $intervalEntity2->method('getUniqueIdentifier')
+            ->willReturn($intervalId2);
+
+        $element1 = new Element($intervalId1, 'Element 1');
+        $element2 = new Element($intervalId2, 'Element 2');
+
+        $configMock->method('getDalField')
+            ->willReturn($dalField);
+        $configMock->method('getAggregationName')
+            ->willReturn($aggregationName);
+        $configMock->method('getIntervals')
+            ->willReturn($intervalCollectionMock);
+
+        $this->rangeAggregationCompatibilityCheckerMock
+            ->expects($this->once())
+            ->method('isDalFieldRangeAggregationCompatible')
+            ->with($dalField)
+            ->willReturn(true);
+
+        $aggregationResultsMock
+            ->expects($this->once())
+            ->method('get')
+            ->with($aggregationName)
+            ->willReturn($rangeResultMock);
+
+        $rangeResultMock
+            ->expects($this->once())
+            ->method('getRanges')
+            ->willReturn([
+                $intervalId1 => [
+                    'count' => 5,
+                ],
+                $intervalId2 => [
+                    'count' => 10,
+                ],
+                $intervalIdNotFound => [
+                    'count' => 3,
+                ],
+            ]);
+
+        $intervalCollectionMock
+            ->expects($this->exactly(3))
+            ->method('get')
+            ->willReturnMap([[$intervalId1, $intervalEntity1], [$intervalId2, $intervalEntity2], [$intervalIdNotFound, null]]);
+
+        $this->elementBuilderMock
+            ->expects($this->exactly(2))
+            ->method('buildElement')
+            ->willReturnMap([[$intervalEntity1, $element1], [$intervalEntity2, $element2]]);
+
+        $this->elementsExtractorForNonCompatibleFieldsMock
+            ->expects($this->never())
+            ->method('extractElementsFromAggregations');
+
+        $result = $this->elementsExtractor->extractElementsFromAggregations($configMock, $aggregationResultsMock);
+
+        $this->assertCount(2, $result);
+        $this->assertContainsEquals($element1, $result);
+        $this->assertContainsEquals($element2, $result);
+        $this->assertEqualsCanonicalizing([$element1, $element2], $result);
+    }
+
+    public function testExtractElementsFromAggregationsForNonCompatibleField(): void
+    {
+        $configMock = $this->createMock(RangeIntervalListingFilterConfigurationEntity::class);
+        $aggregationResultsMock = $this->createMock(AggregationResultCollection::class);
+
+        $dalField = 'product.customField';
+        $expectedElements = [new Element(Uuid::randomHex(), 'Element A'), new Element(Uuid::randomHex(), 'Element B')];
+
+        $configMock->method('getDalField')
+            ->willReturn($dalField);
+
+        $this->rangeAggregationCompatibilityCheckerMock
+            ->expects($this->once())
+            ->method('isDalFieldRangeAggregationCompatible')
+            ->with($dalField)
+            ->willReturn(false);
+
+        $this->elementsExtractorForNonCompatibleFieldsMock
+            ->expects($this->once())
+            ->method('extractElementsFromAggregations')
+            ->with($this->identicalTo($configMock), $this->identicalTo($aggregationResultsMock))
+            ->willReturn($expectedElements);
+
+        $this->elementBuilderMock
+            ->expects($this->never())
+            ->method('buildElement');
+
+        $result = $this->elementsExtractor->extractElementsFromAggregations($configMock, $aggregationResultsMock);
+
+        $this->assertSame($expectedElements, $result);
+    }
+
+    public function testExtractElementsThrowsExceptionIfAggregationNotFound(): void
+    {
+        $configMock = $this->createMock(RangeIntervalListingFilterConfigurationEntity::class);
+        $aggregationResultsMock = $this->createMock(AggregationResultCollection::class);
+
+        $dalField = 'product.price';
+        $aggregationName = 'missing_agg';
+
+        $configMock->method('getDalField')
+            ->willReturn($dalField);
+        $configMock->method('getAggregationName')
+            ->willReturn($aggregationName);
+
+        $this->rangeAggregationCompatibilityCheckerMock
+            ->expects($this->once())
+            ->method('isDalFieldRangeAggregationCompatible')
+            ->with($dalField)
+            ->willReturn(true);
+
+        $aggregationResultsMock
+            ->expects($this->once())
+            ->method('get')
+            ->with($aggregationName)
+            ->willReturn(null);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(sprintf('The aggregation "%s" could not be found.', $aggregationName));
+
+        $this->elementsExtractor->extractElementsFromAggregations($configMock, $aggregationResultsMock);
+    }
+
+    public function testExtractElementsThrowsExceptionIfNotRangeResult(): void
+    {
+        $configMock = $this->createMock(RangeIntervalListingFilterConfigurationEntity::class);
+        $aggregationResultsMock = $this->createMock(AggregationResultCollection::class);
+        $wrongAggregationResultMock = $this->createMock(AggregationResult::class);
+
+        $dalField = 'product.price';
+        $aggregationName = 'wrong_type_agg';
+
+        $configMock->method('getDalField')
+            ->willReturn($dalField);
+        $configMock->method('getAggregationName')
+            ->willReturn($aggregationName);
+
+        $this->rangeAggregationCompatibilityCheckerMock
+            ->expects($this->once())
+            ->method('isDalFieldRangeAggregationCompatible')
+            ->with($dalField)
+            ->willReturn(true);
+
+        $aggregationResultsMock
+            ->expects($this->once())
+            ->method('get')
+            ->with($aggregationName)
+            ->willReturn($wrongAggregationResultMock);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(sprintf('The aggregation result "%s" is not a range result.', $aggregationName));
+
+        $this->elementsExtractor->extractElementsFromAggregations($configMock, $aggregationResultsMock);
+    }
+}

--- a/tests/PHPUnit/Unit/ListingFilter/RangeInterval/Storefront/RenderDataBuilderTest.php
+++ b/tests/PHPUnit/Unit/ListingFilter/RangeInterval/Storefront/RenderDataBuilderTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ITBConfigurableListingFilters\Test\PHPUnit\Unit\ListingFilter\RangeInterval\Storefront;
+
+use ITB\ITBConfigurableListingFilters\Core\Content\ListingFilterConfiguration\RangeInterval\RangeIntervalListingFilterConfigurationEntity;
+use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Storefront\Element;
+use ITB\ITBConfigurableListingFilters\ListingFilter\MultiSelect\Storefront\RenderData;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefront\ElementsExtractorInterface;
+use ITB\ITBConfigurableListingFilters\ListingFilter\RangeInterval\Storefront\RenderDataBuilder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResultCollection;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+#[CoversClass(RenderDataBuilder::class)]
+final class RenderDataBuilderTest extends TestCase
+{
+    private MockObject&ElementsExtractorInterface $elementsExtractorMock;
+
+    private RenderDataBuilder $renderDataBuilder;
+
+    private MockObject&TranslatorInterface $translatorMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->elementsExtractorMock = $this->createMock(ElementsExtractorInterface::class);
+        $this->translatorMock = $this->createMock(TranslatorInterface::class);
+        $this->renderDataBuilder = new RenderDataBuilder($this->elementsExtractorMock, $this->translatorMock);
+    }
+
+    public function testBuildRenderData(): void
+    {
+        $configMock = $this->createMock(RangeIntervalListingFilterConfigurationEntity::class);
+        $aggregationResultsMock = $this->createMock(AggregationResultCollection::class);
+
+        $expectedTemplate = 'test-template.html.twig';
+        $expectedFilterName = 'test-filter-name';
+        $expectedDisplayName = 'Test Filter Display Name';
+        $expectedJsPluginSelector = RenderDataBuilder::JS_PLUGIN_SELECTOR;
+        $expectedTooltip = 'Translated Tooltip';
+
+        $element1 = new Element(Uuid::randomHex(), 'Element 1');
+        $element2 = new Element(Uuid::randomHex(), 'Element 2');
+        $extractedElements = [$element1, $element2];
+
+        $configMock->method('getTwigTemplate')
+            ->willReturn($expectedTemplate);
+        $configMock->method('getFilterName')
+            ->willReturn($expectedFilterName);
+        $configMock->method('getDisplayName')
+            ->willReturn($expectedDisplayName);
+
+        $this->elementsExtractorMock
+            ->expects($this->once())
+            ->method('extractElementsFromAggregations')
+            ->with($this->identicalTo($configMock), $this->identicalTo($aggregationResultsMock))
+            ->willReturn($extractedElements);
+
+        $this->translatorMock
+            ->expects($this->once())
+            ->method('trans')
+            ->with('listing.disabledFilterTooltip')
+            ->willReturn($expectedTooltip);
+
+        $renderData = $this->renderDataBuilder->buildRenderData($configMock, $aggregationResultsMock);
+
+        $this->assertInstanceOf(RenderData::class, $renderData);
+        $this->assertSame($expectedTemplate, $renderData->twigTemplate);
+
+        $expectedArray = [
+            'name' => $expectedFilterName,
+            'displayName' => $expectedDisplayName,
+            'pluginSelector' => $expectedJsPluginSelector,
+            'dataPluginSelectorOptions' => [
+                'name' => $expectedFilterName,
+                'displayName' => $expectedDisplayName,
+                'snippets' => [
+                    'disabledFilterText' => $expectedTooltip,
+                ],
+            ],
+            'elements' => $extractedElements,
+        ];
+
+        $this->assertEquals($expectedArray, $renderData->toArray());
+    }
+}


### PR DESCRIPTION
A range interval filter is a multi-select filter on a numeric field. It allows to define intervals in wich the products are placed/counted. E.g. a the piece count of a product could be separted in intervals that have a meaning in the context of a product.